### PR TITLE
RELEASE-ENGG-2609: Shorten pom version to -RBSD-2609-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
+    <version>17.0.32-RBSD-2609-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>17.0.32-PEG-2848-SNAPSHOT</version>
+    <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>
-        <version>17.103.9-M1</version>
+        <version>17.103.9</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             **/uk/gov/moj/cpp/unifiedsearch/query/api/domain/response/indexdoc2apiresponse/Case.java
         </sonar.cpd.exclusions>
         <mvn.site.url>file://${project.build.directory}/site</mvn.site.url>
-        <usersgroups.version>17.0.37</usersgroups.version>
+        <usersgroups.version>17.104.47</usersgroups.version>
         <cpp-platform-data-utils.version>8.0.17</cpp-platform-data-utils.version>
         <elasticsearch-maven-plugin.version>6.13</elasticsearch-maven-plugin.version>
         <elasticsearch.embedded.version>7.16.2</elasticsearch.embedded.version>

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
+        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
+        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
+        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
+        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
+        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-PEG-2848-REBASED-2609-SNAPSHOT</version>
+        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Shortens the pom version suffix to `-RBSD-2609-SNAPSHOT` so Artifactory snapshot uploads succeed.