### PR TITLE
PEG-2848: Bump pom to -PEG-2848-R-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>17.0.32-RBSD-2609-SNAPSHOT</version>
+    <version>17.0.32-PEG-2848-R-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.0.32-RBSD-2609-SNAPSHOT</version>
+        <version>17.0.32-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Bumps pom versions to -PEG-2848-R-SNAPSHOT for R-candidate build.