### PR TITLE
PEG-2848: azure-pipelines ref to dev/enforcer-disabled

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -21,7 +21,7 @@ resources:
       type: github
       name: hmcts/cpp-azure-devops-templates
       endpoint: 'hmcts'
-      ref: 'main'
+      ref: 'dev/enforcer-disabled'
 
 pool:
   name: "MDV-ADO-AGENT-AKS-01"


### PR DESCRIPTION
Change cppAzureDevOpsTemplates ref from main to dev/enforcer-disabled.