### PR TITLE
PEG-2848: Sync pom properties with team/release-engg-2609

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             **/uk/gov/moj/cpp/unifiedsearch/query/api/domain/response/indexdoc2apiresponse/Case.java
         </sonar.cpd.exclusions>
         <mvn.site.url>file://${project.build.directory}/site</mvn.site.url>
-        <usersgroups.version>17.104.47</usersgroups.version>
+        <usersgroups.version>17.0.41</usersgroups.version>
         <cpp-platform-data-utils.version>8.0.17</cpp-platform-data-utils.version>
         <elasticsearch-maven-plugin.version>6.13</elasticsearch-maven-plugin.version>
         <elasticsearch.embedded.version>7.16.2</elasticsearch.embedded.version>


### PR DESCRIPTION
## Summary
Syncs this repo's `pom.xml` `<properties>` version entries with `team/release-engg-2609`.

## Changes
```
-        <usersgroups.version>17.104.47</usersgroups.version>
+        <usersgroups.version>17.0.41</usersgroups.version>
```

## Why
Part of a 28-repo effort to bring `team/PEG-2848-R` into version-alignment with the passing `release-engg-2609` configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)