### PR TITLE
[CADB-19] Allow users to search by PNC ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>17.104.2-SNAPSHOT</version>
+    <version>17.104.2-CADB-3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.2-SNAPSHOT</version>
+        <version>17.104.2-CADB-3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-api/src/raml/unifiedsearchquery-api.raml
+++ b/unifiedsearchquery-api/src/raml/unifiedsearchquery-api.raml
@@ -26,6 +26,12 @@ baseUri: http://localhost:8080/unifiedsearchquery-query-api/query/api/rest/unifi
        type: string
        required: false
 
+     pncId:
+      description: search for Police National Computer id of a party associated to the case
+      type: string
+      example: 2099/1234567
+      required: false
+
      pageSize:
       description: For pagination only. The number of items to return per page, default is 10
       type: integer

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.2-SNAPSHOT</version>
+        <version>17.104.2-CADB-3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>test-utils-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilder.java
@@ -1,20 +1,53 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
+import java.time.Year;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.PNC_ID_INDEX;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
 import org.elasticsearch.index.query.QueryBuilder;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 
 public class PncIdQueryBuilder implements ElasticSearchQueryBuilder {
+
+    private static final Pattern PNC_ID_PATTERN = Pattern.compile(
+            "^(\\d{2}(\\d{2})?)[/',.\\-_]?([A-Z0-9]{7}[A-Z])$",
+            Pattern.CASE_INSENSITIVE);
+
+    private static final String[] YEAR_DELIMITERS = { "", "/", "'", "-", "_", "." };
 
     @Override
     public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
         final String pncId = valueOf(queryParams[0]);
-        return termQuery(PNC_ID_INDEX, pncId);
+
+        final var matcher = PNC_ID_PATTERN.matcher(pncId);
+        if (matcher.matches()) {
+            // Handle year variations as needed:
+            // - When 2-digit year (eg. 55) is provided, consider current and previous century (eg. 1955 and 2055).
+            // - When 4-digit year (eg. 1955) is provided, use that exact year.
+            final int currentCentury = Year.now(ZoneOffset.UTC).getValue() / 100;
+            final int previousCentury = currentCentury - 1;
+            final String[] yearVariations = matcher.group(1).length() == 2
+                    ? new String[] { currentCentury + matcher.group(1), previousCentury + matcher.group(1) }
+                    : new String[] { matcher.group(1) };
+
+            // Handle a recognised PNC ID by searching for variants.
+            final var terms = Arrays.stream(yearVariations)
+                    .flatMap(year -> Arrays.stream(YEAR_DELIMITERS)
+                        .map(delimiter -> year + delimiter + matcher.group(3)))
+                    .collect(Collectors.toList());
+            return termsQuery(PNC_ID_INDEX, terms);
+        }
+        else {
+            // Handle an unrecognised PNC ID by searching as-is.
+            return termQuery(PNC_ID_INDEX, pncId);
+        }
     }
 }
-
-

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilderTest.java
@@ -1,5 +1,7 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -8,16 +10,23 @@ import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryP
 
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
-import org.junit.jupiter.api.Test;
+import org.elasticsearch.index.query.TermsQueryBuilder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class PncIdQueryBuilderTest {
-    private PncIdQueryBuilder pncIdQueryBuilder = new PncIdQueryBuilder();
+    private final PncIdQueryBuilder pncIdQueryBuilder = new PncIdQueryBuilder();
 
-
-    @Test
-    public void shouldCreateExactMatchQueryBuilderForPncIdNumber() {
-
-        final String pncId = "123456";
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // Values that are obviously not a PNC ID.
+            "123456", "TEST", "SJ123456789",
+            // Values which are almost valid PNC IDs.
+            "21234567T", "2012345678T", "211234567TQ",
+            "2011234567T", "201712345678T", "201234567TQ",
+    })
+    public void shouldQueryExactMatchForUnrecognisedPncId(final String pncId) {
         final QueryBuilder queryBuilder = pncIdQueryBuilder.getQueryBuilderBy(pncId);
 
         assertThat(queryBuilder, is(notNullValue()));
@@ -27,6 +36,40 @@ public class PncIdQueryBuilderTest {
         final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) queryBuilder;
         assertThat(termQueryBuilder.getName(), is("term"));
         assertThat(termQueryBuilder.fieldName(), is(PNC_ID_INDEX));
-        assertThat(termQueryBuilder.value(), is("123456"));
+        assertThat(termQueryBuilder.value(), is(pncId));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            // Delimiter may be "/", "-", "_", ".", "'", or omitted.
+            // Input does not include century; consider current and previous centuries:
+            "171234567T, 19171234567T 1917/1234567T 1917-1234567T 1917_1234567T 1917.1234567T 1917'1234567T 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+            "17/1234567T, 19171234567T 1917/1234567T 1917-1234567T 1917_1234567T 1917.1234567T 1917'1234567T 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+            "17-1234567T, 19171234567T 1917/1234567T 1917-1234567T 1917_1234567T 1917.1234567T 1917'1234567T 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+            "17_1234567T, 19171234567T 1917/1234567T 1917-1234567T 1917_1234567T 1917.1234567T 1917'1234567T 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+            "17.1234567T, 19171234567T 1917/1234567T 1917-1234567T 1917_1234567T 1917.1234567T 1917'1234567T 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+            "17'1234567T, 19171234567T 1917/1234567T 1917-1234567T 1917_1234567T 1917.1234567T 1917'1234567T 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+            // Input is an exact year; use as-is:
+            "20171234567T, 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+            "2017/1234567T, 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+            "2017-1234567T, 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+            "2017_1234567T, 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+            "2017.1234567T, 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+            "2017'1234567T, 20171234567T 2017/1234567T 2017-1234567T 2017_1234567T 2017.1234567T 2017'1234567T",
+    })
+    public void shouldQueryVariantsForRecognisedPncId(final String inputPncId,
+                                                      final String expectedTermsRaw) {
+        final QueryBuilder queryBuilder = pncIdQueryBuilder.getQueryBuilderBy(inputPncId);
+
+        assertThat(queryBuilder, is(notNullValue()));
+
+        assertThat(queryBuilder, instanceOf(TermsQueryBuilder.class));
+
+        final var expectedTerms = expectedTermsRaw.split(" ");
+
+        final TermsQueryBuilder termQueryBuilder = (TermsQueryBuilder) queryBuilder;
+        assertThat(termQueryBuilder.getName(), is("terms"));
+        assertThat(termQueryBuilder.fieldName(), is(PNC_ID_INDEX));
+        assertThat(termQueryBuilder.values(), hasItems(expectedTerms));
     }
 }

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.2-SNAPSHOT</version>
+        <version>17.104.2-CADB-3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.2-SNAPSHOT</version>
+        <version>17.104.2-CADB-3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.2-SNAPSHOT</version>
+        <version>17.104.2-CADB-3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/CaseReferenceSearchIT.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/CaseReferenceSearchIT.java
@@ -20,6 +20,7 @@ import uk.gov.moj.unifiedsearch.query.it.ingestors.ReferenceSearchDataIngester;
 import uk.gov.moj.unifiedsearch.query.it.util.SearchApiClient;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -32,6 +33,7 @@ public class CaseReferenceSearchIT {
 
     private static final ReferenceSearchDataIngester referenceSearchDataHelper = new ReferenceSearchDataIngester();
     private static final String CASE_REFERENCE = "caseReference";
+    private static final String PNC_ID = "pncId";
     private static final String SORT_ASC = "asc";
     private static final String SORT_DESC = "desc";
     private static final String SORT_BY_APPOINTMENT_DATE = "sortByAppointmentDate";
@@ -202,5 +204,43 @@ public class CaseReferenceSearchIT {
         assertThat(caseSearchResponse.getCases(), hasSize(1));
         final Case firstCase = caseSearchResponse.getCases().get(0);
         assertCase(firstCase, secondCaseDocument);
+    }
+
+    @Test
+    public void shouldReturnSearchResponseWhenSearchingByPncId() throws IOException {
+        final CaseDocument firstCaseDocument = referenceSearchDataHelper.getIndexDocumentAt(9);
+        final String pncId = firstCaseDocument.getParties().get(0).getPncId();
+
+        final Map<String, String> parameters = of(PNC_ID, pncId);
+
+        final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
+
+        assertCases(caseSearchResponse, singletonList(firstCaseDocument));
+    }
+
+    @Test
+    public void shouldReturnMultipleSearchResponsesWhenSearchingByPncId() throws IOException {
+        final CaseDocument firstCaseDocument = referenceSearchDataHelper.getIndexDocumentAt(10);
+        final CaseDocument secondCaseDocument = referenceSearchDataHelper.getIndexDocumentAt(11);
+        final String pncId = firstCaseDocument.getParties().get(0).getPncId();
+
+        final Map<String, String> parameters = of(PNC_ID, pncId);
+
+        final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
+
+        assertCases(caseSearchResponse, List.of(firstCaseDocument, secondCaseDocument));
+    }
+
+    @Test
+    public void shouldReturnResponsesWhenSearchingByPncIdWithShortYearForm() throws IOException {
+        final CaseDocument firstCaseDocument = referenceSearchDataHelper.getIndexDocumentAt(10);
+        final CaseDocument secondCaseDocument = referenceSearchDataHelper.getIndexDocumentAt(11);
+        final String pncId = firstCaseDocument.getParties().get(0).getPncId().substring(2);
+
+        final Map<String, String> parameters = of(PNC_ID, pncId);
+
+        final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
+
+        assertCases(caseSearchResponse, List.of(firstCaseDocument, secondCaseDocument));
     }
 }

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/ingestors/ReferenceSearchDataIngester.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/ingestors/ReferenceSearchDataIngester.java
@@ -32,6 +32,9 @@ public class ReferenceSearchDataIngester {
     public static final String TVL_CASE_REFERENCE = "TVL1234567";
     public static final String TVL_CASE_2_REFERENCE = "TVL2345678";
     public static final String TVL_CASE_3_REFERENCE = "TVL3456789";
+    public static final String TVL_CASE_4_REFERENCE = "TVL3456790";
+    public static final String TVL_CASE_5_REFERENCE = "TVL3456791";
+    public static final String TVL_CASE_6_REFERENCE = "TVL3456792";
     public static final String APP_REFERENCE_PREFIX = "APPUSRS000";
     public static final String TFL_CASE8_REFERENCE = "TFL987654322";
     private final ElasticSearchIndexIngestorUtil elasticSearchIndexIngestorUtil = new ElasticSearchIndexIngestorUtil();
@@ -50,7 +53,7 @@ public class ReferenceSearchDataIngester {
 
 
     private List<CaseDocument> caseListForReferenceSearch() {
-        final List<CaseDocument.Builder> caseBuilderList = defaultCasesAsBuilderList(9);
+        final List<CaseDocument.Builder> caseBuilderList = defaultCasesAsBuilderList(12);
 
         caseBuilderList.get(0).withCaseReference(TFL_CASE_REFERENCE).withProsecutingAuthority("TFL").
                 withParties(ImmutableList.of(createPartyBuilder())).
@@ -91,6 +94,11 @@ public class ReferenceSearchDataIngester {
         caseBuilderList.get(8).withCaseReference(TFL_CASE8_REFERENCE).withProsecutingAuthority("CASE8").withParties(of(createPartyBuilder()))
                 .withHearings(of(defaultHearingAsBuilder().withHearingDays(of(defaultHearingDayDocumentAsBuilder().withSittingDay("2021-03-22T09:00:00").build(), createHearingDayDocument())),
                         defaultHearingAsBuilder().withHearingDays(of(createHearingDayDocument(), createHearingDayDocument()))));
+
+        // Case with PNC ID of varying formats
+        caseBuilderList.get(9).withCaseReference(TVL_CASE_4_REFERENCE).withProsecutingAuthority("TEST").withParties(of(createPartyBuilder().withPncId("20171234567Q")));
+        caseBuilderList.get(10).withCaseReference(TVL_CASE_5_REFERENCE).withProsecutingAuthority("TEST").withParties(of(createPartyBuilder().withPncId("20191234567T")));
+        caseBuilderList.get(11).withCaseReference(TVL_CASE_6_REFERENCE).withProsecutingAuthority("TEST").withParties(of(createPartyBuilder().withPncId("2019/1234567T")));
 
         return caseBuilderList.stream()
                 .map(CaseDocument.Builder::build)

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.2-SNAPSHOT</version>
+        <version>17.104.2-CADB-3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
### Jira link

See [CADB-19](https://tools.hmcts.net/jira/browse/CADB-19)

### Change description

This PR makes the following changes:
- Amend RAML file for search API to allow `pncId` to be provided.
- Amend existing `PncIdQueryBuilder` so that PNC ID's can be queried allowing for multiple input formats and allowing for multiple formats which may exist in the existing search index (the existing XSD allows multiple PNC ID formats; and the UI allows users to freely input any format).

### Testing done

Unit tests and integration tests have been updated to accommodate these changes.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
