### PR TITLE
[CADB-17] Amend regular expression to exclude invalid PNC IDs

### DIFF
--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilder.java
@@ -18,7 +18,7 @@ import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 public class PncIdQueryBuilder implements ElasticSearchQueryBuilder {
 
     private static final Pattern PNC_ID_PATTERN = Pattern.compile(
-            "^(\\d{2}(\\d{2})?)[/',.\\-_]?([A-Z0-9]{7}[A-Z])$",
+            "^(\\d{2}(\\d{2})?)[/',.\\-_]?(\\d{7}[A-HJ-NP-RT-Z])$",
             Pattern.CASE_INSENSITIVE);
 
     private static final String[] YEAR_DELIMITERS = { "", "/", "'", "-", "_", "." };

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilderTest.java
@@ -23,8 +23,8 @@ public class PncIdQueryBuilderTest {
             // Values that are obviously not a PNC ID.
             "123456", "TEST", "SJ123456789",
             // Values which are almost valid PNC IDs.
-            "21234567T", "2012345678T", "211234567TQ",
-            "2011234567T", "201712345678T", "201234567TQ",
+            "21234567T", "2012345678T", "211234567TQ", "171234567I", "171234567O", "171234567S",
+            "2011234567T", "201712345678T", "201234567TQ", "20171234567I", "20171234567O", "20171234567S",
     })
     public void shouldQueryExactMatchForUnrecognisedPncId(final String pncId) {
         final QueryBuilder queryBuilder = pncIdQueryBuilder.getQueryBuilderBy(pncId);


### PR DESCRIPTION
### Jira link

Related tickets:
- [CADB-17](https://tools.hmcts.net/jira/browse/PROJCADB-17)
- [CADB-19](https://tools.hmcts.net/jira/browse/PROJCADB-17)
- [CADB-3](https://tools.hmcts.net/jira/browse/PROJCADB-17)

### Change description

A valid PNC ID will have 7 numeric digits following the year and optional delimiter.

A valid PNC ID cannot end with the check characters 'I', 'O', or 'S'.

Since invalid PNC IDs should be treated as case references; these have been excluded from the PNC ID detection regular expression.

### Testing done

Unit tests have been updated to reflect this minor adjustment.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
