### PR TITLE
Upgrade to Java 25 / WildFly 40 / Elasticsearch 9.3.3 (PEG-3408)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md — cpp-context-unifiedsearch-query
+
+Context-specific notes for the **Java 25 / WildFly 40 / Elasticsearch 9.2.2** upgrade (25.104.x). See the platform-wide guidance in the workspace root `CLAUDE.md`.
+
+## ⚠️ BEHAVIOUR CHANGE — `pageSize=0` (watch API Tests)
+
+During the ES 9.2.2 upgrade we changed how `pageSize=0` is handled on the search endpoints:
+
+- **Before:** `pageSize=0` → Elasticsearch `size:0` → the query matched documents but returned an **empty result list**.
+- **Now:** `pageSize=0` (and an **absent** `pageSize`, which the framework materialises as `0`) → **uses the default page size of 10**, returning results.
+- **Unchanged:** a **negative** `pageSize` is still **rejected** as invalid (`BadRequestException "Invalid page size"`).
+
+Implemented in `getPageSize()` of `CpsQueryParameters` and `QueryParameters` (`return pageSize == 0 ? 10 : pageSize`).
+
+**Why:** the RAML-generated resource does not translate the RAML `default:` into a JAX-RS `@DefaultValue`, and the framework's parameter pipeline materialises an absent numeric query param as `0` — so an absent `pageSize` was reaching ES as `size:0` and returning nothing. Absent and explicit-`0` are indistinguishable by the time our code sees them, so the contract was set to "`0` means default page".
+
+**API Test impact:** API Tests exercise real contexts across boundaries. **If an API Test involving unifiedsearch-query starts returning results where it previously got an empty list (a caller sending `pageSize=0`), this change is the cause.** Such a test should be updated to the new contract (send an explicit positive `pageSize` if it needs a specific page, or expect the default page for `pageSize=0`).
+
+## ES 9.2.2 client notes
+
+- The unified-search client migrated from `RestHighLevelClient` to `co.elastic.clients:elasticsearch-java` (in `cpp-platform-libraries`, cherry-picked from Java-17 DD-41592).
+- `httpcore5` is pinned to `5.3.6` in the platform BOM (elasticsearch-rest-client 9.2.2 pins 5.2.1, which clashes with `httpclient5 5.5.1` → `NoSuchMethodError` on real ES HTTP calls; only shows in ITs, not embedded-ES unit tests).
+- `CpsCaseSortBy.findByKeyNameOrDefault` uses `computeIfAbsent` (an unknown `orderBy` returns the `URN` default, not null — previously `putIfAbsent` returned null → NPE/500).
+- ITs run against a real ES 9.2.2 container (`cpp-developers-docker`), with embedded ES 9.2.2 for unit tests via `elasticsearch-maven-plugin`.

--- a/README-Java-25-and-Elasticsearch-9.2.2-Upgrade.md
+++ b/README-Java-25-and-Elasticsearch-9.2.2-Upgrade.md
@@ -1,0 +1,94 @@
+# Java 25 / WildFly 40 / Elasticsearch 9.2.2 upgrade — guide for the unifiedsearch-query team
+
+This branch (`dev/java-25-es-9.2.2`, draft PR **#27**) upgrades unifiedsearch-query to the **25.104.x** line
+(Java 25 / WildFly 40 / Jakarta EE 11) **and** to **Elasticsearch 9.2.2**. It was prepared by the platform/framework
+upgrade effort (ticket **PEG-3408**, mirroring the Java-17 ES 9.2 work in **DD-41592**) as a *proving* exercise.
+
+**The decision to accept, finish and release these changes is yours.** This document explains what we changed, the
+decisions we made and why, the gotchas we hit, and exactly what you need to do to take it over the line.
+
+---
+
+## Why
+
+- Elasticsearch 9.2.2 is being rolled out on the Java-17 line; we needed to prove it also works on the Java-25 stack.
+- Folded into the July 2026 security-hardening work (jackson `2.21.5` etc.).
+
+## What changed (summary)
+
+- **Parent** → `service-parent-pom:25.104.0-M8-SNAPSHOT` (Java 25 / WildFly 40 / Jakarta EE 11).
+- **`javax.*` → `jakarta.*`** across all modules; `javax:javaee-api` → `jakarta.platform:jakarta.jakartaee-api`;
+  `jakarta.xml.bind-api` override added to the RAML client-generator plugins; RESTEasy status-code constant fix in ITs.
+- **Elasticsearch client** migrated from `RestHighLevelClient` to `co.elastic.clients:elasticsearch-java` +
+  `elasticsearch-rest-client` (this lives in `cpp-platform-libraries` and is shared; cherry-picked from DD-41592).
+- Two small **context-code fixes** (below).
+
+---
+
+## Decisions we made — please review these
+
+### 1. ⚠️ `pageSize=0` now returns the default page (BEHAVIOUR CHANGE — API Test risk)
+
+This is the decision most worth your attention.
+
+- **Before:** `pageSize=0` → Elasticsearch `size:0` → matched documents but returned an **empty list**.
+- **Now:** `pageSize=0` — **and an *absent* `pageSize`** — returns the **default page of 10**.
+- **Unchanged:** a **negative** `pageSize` is still rejected (`BadRequestException "Invalid page size"`).
+
+**Why we had to change it:** the framework materialises an *absent* numeric query param as `0` (verified for `int`
+*and* `Integer` in the deployed bytecode), and the RAML `default:` is **not** emitted as a JAX-RS `@DefaultValue` by
+the generator. So "absent" and "explicit 0" are indistinguishable by the time our code sees them — and an absent
+`pageSize` was reaching ES as `size:0` and returning nothing. We chose the contract **`0` → default page of 10**
+(a zero-size page is meaningless). Implemented in `getPageSize()` of `CpsQueryParameters` and `QueryParameters`.
+
+**What you should do:** check your **API Tests** (the cross-context tests that use real contexts). If one that calls
+unifiedsearch-query with `pageSize=0` previously asserted an empty list, it will now get the default page — update it
+(send an explicit positive `pageSize`, or expect the default page). If you'd prefer a different contract, this is the
+one decision we'd flag for a conversation before release.
+
+### 2. `CpsCaseSortBy.findByKeyNameOrDefault`: `putIfAbsent` → `computeIfAbsent`
+
+The original used `Map.putIfAbsent`, which **returns null** for a key that wasn't present — so an unrecognised
+`orderBy` value produced a 500. Changed to `computeIfAbsent(key -> URN)` so an unknown key resolves to the `URN`
+default (and is cached), which is what the method name promises.
+
+### 3. Shared ES-client change lives in the platform, not here
+
+The `RestHighLevelClient` → `co.elastic` migration is in `cpp-platform-libraries` (shared by all search contexts),
+not in this repo. You inherit it via the platform version. `httpcore5` is pinned to `5.3.6` in the platform BOM
+(ES 9.2.2 pulls `5.2.1`, which clashes with `httpclient5 5.5.1` → `NoSuchMethodError` — only shows up in ITs).
+
+---
+
+## Gotchas we hit (so you don't have to)
+
+- **RAML `default:` on a query param is not honoured** by this generator, and the framework turns an absent numeric
+  param into `0` — hence decision #1. `putOptional` omits nulls but doesn't recover the absent-vs-0 distinction.
+- **Local Elasticsearch (dev docker)** needed ES-9 changes: new base image, dev TLS-off + security enabled, non-root
+  file permissions, and the security-provisioning API path `_xpack/security` → `_security`. These are in
+  `cpp-developers-docker` (already done); you only need an up-to-date local stack to run the ITs.
+- ES 9 sorting on `keyword` / text `.keyword` fields works unchanged.
+
+---
+
+## Test evidence
+
+- **Full-stack integration tests: 332 / 0 / 0** (3 skipped) against a live ES 9.2.2 container + WildFly 40 on JDK 25.
+- 202 unit / embedded-ES tests green; platform ES-client migration 92 tests green.
+
+---
+
+## What you need to do to accept & release
+
+1. **Review decision #1** (`pageSize=0`) with whoever owns the API Tests, and decisions #2–#3.
+2. Wait for the **25.104.x framework/platform milestones to be released** to Artifactory (this PR is a **draft**
+   because it currently references a `-SNAPSHOT` parent, so CI can't build it yet).
+3. Bump the **parent** from `25.104.0-M8-SNAPSHOT` to the released milestone; likewise any other SNAPSHOT platform deps.
+4. Run the build + ITs (`./runIntegrationTests.sh`) against a current local stack; expect the same green result.
+5. Set the project version per the release scheme, mark PR **#27** ready, and release.
+
+## References
+
+- Draft PR: **#27** · Tickets: **PEG-3408**, **DD-41592**
+- Living upgrade page: *Elasticsearch 9.2.2 Upgrade — Java 25* (Confluence, space PETTA, page 1990251336)
+- AI-assistant notes for this repo: `CLAUDE.md` (same content, terser).

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -21,12 +21,12 @@ resources:
       type: github
       name: hmcts/cpp-azure-devops-templates
       endpoint: 'hmcts'
-      ref: 'main'
+      ref: 'wildfly40'
 
 pool:
   name: "MDV-ADO-AGENT-AKS-01"
   demands:
-    - identifier -equals centos8-j17
+    - identifier -equals ubuntu-j25
 
 variables:
   sonarqubeProject: "uk.gov.moj.cpp.unifiedsearch.query:unifiedsearchquery-parent" # update eg: uk.gov.moj.cpp.listing:listing-parent
@@ -47,3 +47,4 @@ stages:
           sonarQubeType: 'sonarQubeAKS'
           serviceName: ${{ variables['service_Name'] }}
           itTestFolder: ${{ variables['itTest_Folder'] }}
+          aksDeployBranch: 'wildfly40'

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>
-        <version>17.103.5</version>
+        <version>17.103.9-M2</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
@@ -32,7 +32,7 @@
         <usersgroups.version>17.0.41</usersgroups.version>
         <cpp-platform-data-utils.version>8.0.17</cpp-platform-data-utils.version>
         <elasticsearch-maven-plugin.version>6.13</elasticsearch-maven-plugin.version>
-        <elasticsearch.embedded.version>7.16.2</elasticsearch.embedded.version>
+        <elasticsearch.embedded.version>9.2.2</elasticsearch.embedded.version>
         <jgitflow.maven.developBranchName>main</jgitflow.maven.developBranchName>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>17.103.1-DD-41592-SNAPSHOT</version>
+    <version>17.103.2-DD-41592-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>17.103.1-SNAPSHOT</version>
+    <version>17.103.1-DD-41592-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>17.103.2-DD-41592-SNAPSHOT</version>
+    <version>17.103.3-DD-41592-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>17.103.3-DD-41592-SNAPSHOT</version>
+    <version>17.103.4-DD-41592-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>17.104.4-DD-41592-SNAPSHOT</version>
+    <version>17.104.5-DD-41592-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>
-        <version>25.104.0-M8</version>
+        <version>25.104.0-M9</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
@@ -32,7 +32,7 @@
         <usersgroups.version>17.104.48</usersgroups.version>
         <cpp-platform-data-utils.version>8.0.17</cpp-platform-data-utils.version>
         <elasticsearch-maven-plugin.version>6.13</elasticsearch-maven-plugin.version>
-        <elasticsearch.embedded.version>9.2.2</elasticsearch.embedded.version>
+        <elasticsearch.embedded.version>9.3.3</elasticsearch.embedded.version>
         <jgitflow.maven.developBranchName>main</jgitflow.maven.developBranchName>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>17.103.4-DD-41592-SNAPSHOT</version>
+    <version>17.104.4-DD-41592-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>
-        <version>17.104.4-M3</version>
+        <version>25.104.0-M8</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>17.104.5-DD-41592-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-SNAPSHOT</version>
+        <version>17.103.1-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-DD-41592-SNAPSHOT</version>
+        <version>17.103.2-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.2-DD-41592-SNAPSHOT</version>
+        <version>17.103.3-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.5-DD-41592-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,8 +16,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -85,9 +85,14 @@
                 <artifactId>rest-client-generator-plugin</artifactId>
                 <dependencies>
                     <dependency>
-                        <groupId>javax</groupId>
-                        <artifactId>javaee-api</artifactId>
+                        <groupId>jakarta.platform</groupId>
+                        <artifactId>jakarta.jakartaee-api</artifactId>
                         <version>${javaee-api.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>uk.gov.moj.cpp.usersgroups</groupId>

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.5-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.3-DD-41592-SNAPSHOT</version>
+        <version>17.103.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/CaseQueryApi.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/CaseQueryApi.java
@@ -18,8 +18,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.common.domain.QueryParameters;
 
 import java.util.List;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 @ServiceComponent(QUERY_API)
 public class CaseQueryApi {

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/CpsCaseQueryApi.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/CpsCaseQueryApi.java
@@ -20,8 +20,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.api.response.SearchResponseEnvelopeGen
 import uk.gov.moj.cpp.unifiedsearch.query.api.service.CpsCaseSearchService;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.CpsQueryParameters;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 @ServiceComponent(QUERY_API)
 public class CpsCaseQueryApi {

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/DefendantCaseQueryApi.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/DefendantCaseQueryApi.java
@@ -17,8 +17,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.api.service.CaseSearchService;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.DefendantQueryParameters;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.QueryParameters;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 @ServiceComponent(QUERY_API)
 public class DefendantCaseQueryApi {

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/DefendantDetailsQueryApi.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/DefendantDetailsQueryApi.java
@@ -17,8 +17,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.api.service.CaseSearchService;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.DefendantDetailsQueryParameters;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.QueryParameters;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 @ServiceComponent(QUERY_API)
 public class DefendantDetailsQueryApi {

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/LaaCaseQueryApi.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/LaaCaseQueryApi.java
@@ -17,8 +17,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.api.service.CaseSearchService;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.LaaQueryParameters;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.QueryParameters;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 @ServiceComponent(QUERY_API)
 public class LaaCaseQueryApi {

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/response/SearchResponseEnvelopeGenerator.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/response/SearchResponseEnvelopeGenerator.java
@@ -5,8 +5,8 @@ import static uk.gov.justice.services.messaging.JsonEnvelope.envelopeFrom;
 import uk.gov.justice.services.messaging.JsonEnvelope;
 import uk.gov.justice.services.messaging.Metadata;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 public class SearchResponseEnvelopeGenerator {
 

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/response/SearchResponseMetadataGenerator.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/response/SearchResponseMetadataGenerator.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class SearchResponseMetadataGenerator {
 

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CaseSearchService.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CaseSearchService.java
@@ -116,7 +116,7 @@ public class CaseSearchService implements BaseCaseSearchService {
                 .field(f -> f
                         .field(COURT_PROCEEDINGS_INITIATED)
                         .order(co.elastic.clients.elasticsearch._types.SortOrder.Asc)
-                        .nested(n -> n.path("parties"))
+                        .nested(n -> n.path(RESULT_INNER_HIT_NODE_NAME))
                 )
         );
 

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CaseSearchService.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CaseSearchService.java
@@ -20,12 +20,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.json.JsonArray;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CpsCaseSearchService.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CpsCaseSearchService.java
@@ -19,10 +19,11 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.json.JsonObject;
 
+import co.elastic.clients.elasticsearch._types.SortOptions;
+import co.elastic.clients.elasticsearch._types.SortOrder;
 import org.apache.commons.lang3.StringUtils;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.search.sort.FieldSortBuilder;
-import org.elasticsearch.search.sort.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+
 
 @ApplicationScoped
 public class CpsCaseSearchService implements BaseCaseSearchService {
@@ -35,8 +36,8 @@ public class CpsCaseSearchService implements BaseCaseSearchService {
     private UnifiedSearchQueryBuilderService unifiedSearchQueryBuilderService;
 
     public JsonObject searchCases(final CpsQueryParameters queryParameters) {
-        final QueryBuilder queryBuilder = unifiedSearchQueryBuilderService.builder(queryParameters);
-        final Optional<FieldSortBuilder> fieldSortBuilder = getSortBuilder(queryParameters);
+        final Query.Builder queryBuilder = unifiedSearchQueryBuilderService.builder(queryParameters);
+        final Optional<SortOptions> fieldSortBuilder = getSortBuilder(queryParameters);
 
         return unifiedSearchService.search(
                 queryBuilder,
@@ -48,7 +49,7 @@ public class CpsCaseSearchService implements BaseCaseSearchService {
                 fieldSortBuilder.orElse(null));
     }
 
-    private Optional<FieldSortBuilder> getSortBuilder(final CpsQueryParameters queryParameters) {
+    private Optional<SortOptions> getSortBuilder(final CpsQueryParameters queryParameters) {
         if (StringUtils.isNotEmpty(queryParameters.getOrderBy())) {
             final CpsCaseSortBy cpsCaseSortBy = findByKeyNameOrDefault(queryParameters.getOrderBy());
 
@@ -60,10 +61,10 @@ public class CpsCaseSearchService implements BaseCaseSearchService {
                     cpsCaseSortBy.getNestedMaxChildren().orElse(null));
         }
 
-        return createFieldSort(SortOrder.ASC.name(), URN, null);
+        return createFieldSort(SortOrder.Asc.name(), URN, null);
     }
 
-    private String getOrderNameOrDefault(final SortOrder order) {
-        return isNull(order) ? SortOrder.ASC.name() : order.name();
+    private String getOrderNameOrDefault(final uk.gov.moj.cpp.unifiedsearch.query.common.constant.SortOrder order) {
+        return isNull(order) ? SortOrder.Asc.name() : order.getOrder();
     }
 }

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CpsCaseSearchService.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CpsCaseSearchService.java
@@ -15,9 +15,9 @@ import uk.gov.moj.cpp.unifiedsearch.query.common.domain.response.cps.Case;
 
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/QueryApiPreConditions.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/QueryApiPreConditions.java
@@ -18,7 +18,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.common.domain.QueryParameters;
 
 import java.util.List;
 
-import org.elasticsearch.search.sort.SortOrder;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+
 
 public class QueryApiPreConditions {
     private static final String HEARING_DATE_FROM_IS_AFTER_HEARING_DATE_TO = "Hearing Date From: %s is after Hearing Date To: %s";

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/UsersGroupsService.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/UsersGroupsService.java
@@ -17,9 +17,9 @@ import uk.gov.moj.cpp.unifiedsearch.query.common.domain.PermissionList;
 
 import java.util.List;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 
 @ApplicationScoped

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/util/ApplicationTypeFilter.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/util/ApplicationTypeFilter.java
@@ -14,11 +14,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import javax.inject.Inject;
-import javax.json.JsonArray;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
+import jakarta.inject.Inject;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 public class ApplicationTypeFilter {
 

--- a/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/util/LAAResultFilter.java
+++ b/unifiedsearchquery-api/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/api/util/LAAResultFilter.java
@@ -6,11 +6,11 @@ import static uk.gov.justice.services.messaging.JsonObjects.createObjectBuilder;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import javax.json.JsonArray;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
-import javax.json.JsonValue;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
 
 public class LAAResultFilter {
 

--- a/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/CaseQueryApiTest.java
+++ b/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/CaseQueryApiTest.java
@@ -21,8 +21,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.api.util.ApplicationTypeFilter;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.QueryParameters;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.builders.QueryParametersBuilder;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/CpsCaseQueryApiTest.java
+++ b/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/CpsCaseQueryApiTest.java
@@ -20,7 +20,7 @@ import uk.gov.moj.cpp.unifiedsearch.query.api.response.SearchResponseEnvelopeGen
 import uk.gov.moj.cpp.unifiedsearch.query.api.service.CpsCaseSearchService;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.CpsQueryParameters;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/DefendantCaseQueryApiTest.java
+++ b/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/DefendantCaseQueryApiTest.java
@@ -18,7 +18,7 @@ import uk.gov.moj.cpp.unifiedsearch.query.api.service.CaseSearchService;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.DefendantQueryParameters;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.QueryParameters;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/DefendantDetailsQueryApiTest.java
+++ b/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/DefendantDetailsQueryApiTest.java
@@ -20,7 +20,7 @@ import uk.gov.moj.cpp.unifiedsearch.query.api.service.CaseSearchService;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.DefendantDetailsQueryParameters;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.QueryParameters;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/LaaCaseQueryApiTest.java
+++ b/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/LaaCaseQueryApiTest.java
@@ -20,7 +20,7 @@ import uk.gov.moj.cpp.unifiedsearch.query.api.service.CaseSearchService;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.LaaQueryParameters;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.QueryParameters;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/response/SearchResponseEnvelopeGeneratorTest.java
+++ b/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/response/SearchResponseEnvelopeGeneratorTest.java
@@ -9,7 +9,7 @@ import uk.gov.justice.services.messaging.JsonEnvelope;
 import uk.gov.justice.services.messaging.Metadata;
 import uk.gov.justice.services.messaging.MetadataBuilder;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CaseSearchServiceTest.java
+++ b/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CaseSearchServiceTest.java
@@ -30,9 +30,9 @@ import uk.gov.moj.cpp.unifiedsearch.query.common.domain.defendant.ProbationDefen
 
 import java.util.UUID;
 
-import javax.json.JsonArray;
-import javax.json.JsonNumber;
-import javax.json.JsonObject;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
 
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;

--- a/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CpsCaseSearchServiceTest.java
+++ b/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/service/CpsCaseSearchServiceTest.java
@@ -19,7 +19,7 @@ import uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSortBy;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.CpsQueryParameters;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.response.cps.Case;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;

--- a/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/util/ApplicationTypeFilterTest.java
+++ b/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/util/ApplicationTypeFilterTest.java
@@ -19,8 +19,8 @@ import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.util.List;
 
-import javax.json.JsonObject;
-import javax.json.JsonReader;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
 
 import com.google.common.io.Resources;
 import org.junit.jupiter.api.Test;

--- a/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/util/LAAResultFilterTest.java
+++ b/unifiedsearchquery-api/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/api/util/LAAResultFilterTest.java
@@ -8,9 +8,9 @@ import static uk.gov.justice.services.messaging.JsonObjects.createObjectBuilder;
 
 import java.util.UUID;
 
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-SNAPSHOT</version>
+        <version>17.103.1-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-DD-41592-SNAPSHOT</version>
+        <version>17.103.2-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.2-DD-41592-SNAPSHOT</version>
+        <version>17.103.3-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.5-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.3-DD-41592-SNAPSHOT</version>
+        <version>17.103.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.5-DD-41592-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -11,8 +11,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/UnifiedSearchQueryBuilderProducer.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/UnifiedSearchQueryBuilderProducer.java
@@ -9,11 +9,11 @@ import uk.gov.justice.services.unifiedsearch.UnifiedSearchName;
 import uk.gov.moj.cpp.unifiedsearch.query.builders.service.CaseQueryBuilderService;
 import uk.gov.moj.cpp.unifiedsearch.query.builders.service.CpsCaseQueryBuilderService;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.InjectionException;
-import javax.enterprise.inject.Produces;
-import javax.enterprise.inject.spi.InjectionPoint;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.InjectionException;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 class UnifiedSearchQueryBuilderProducer {

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/UnifiedSearchQueryBuilderService.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/UnifiedSearchQueryBuilderService.java
@@ -1,8 +1,8 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public interface UnifiedSearchQueryBuilderService<T> {
 
-    QueryBuilder builder(final T queryParameters);
+    Query.Builder builder(final T queryParameters);
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/ElasticSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/ElasticSearchQueryBuilder.java
@@ -2,12 +2,130 @@ package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch;
 
 import static java.lang.String.valueOf;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import java.util.Arrays;
+import java.util.List;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.DisMaxQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MultiMatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
 
 public interface ElasticSearchQueryBuilder {
-    QueryBuilder getQueryBuilderBy(final Object... queryParams);
+    Query getQueryBuilderBy(final Object... queryParams);
 
     default String[] clean(final Object queryParam) {
         return valueOf(queryParam).replaceAll("\\s", "").split(",");
+    }
+
+    static Query.Builder termQuery(String name, String value){
+        final Query.Builder builder = new Query.Builder();
+        builder.term(t -> t
+                .field(name)
+                .value(value));
+        return builder;
+    }
+
+    static Query.Builder termQuery(String name, Boolean value){
+        final Query.Builder builder = new Query.Builder();
+        builder.term(t -> t
+                .field(name)
+                .value(value));
+        return builder;
+    }
+
+    static Query.Builder termsQuery(String name, String... value){
+        final Query.Builder builder = new Query.Builder();
+        builder.terms(t -> t
+                .field(name)
+                .terms(v -> v.value(
+                        Arrays.stream(value)
+                                .map(FieldValue::of)
+                                .toList())));
+        return builder;
+    }
+
+    static Query.Builder termsQuery(String name, List<String> value){
+        final Query.Builder builder = new Query.Builder();
+        builder.terms(t -> t
+                .field(name)
+                .terms(v -> v.value(
+                        value.stream()
+                                .map(FieldValue::of)
+                                .toList())));
+        return builder;
+    }
+
+    static NestedQuery.Builder nestedQuery(String path, Query.Builder query){
+        final NestedQuery.Builder builder = new NestedQuery.Builder();
+
+        builder.path(path).query(query.build()).scoreMode(ChildScoreMode.Avg);
+        return builder;
+    }
+
+    static NestedQuery.Builder nestedQuery(String path, Query query){
+        final NestedQuery.Builder builder = new NestedQuery.Builder();
+
+        builder.path(path).query(query).scoreMode(ChildScoreMode.Avg);
+        return builder;
+    }
+
+    static MatchQuery.Builder matchQuery(String name, String text) {
+        final MatchQuery.Builder builder = new MatchQuery.Builder();
+        builder.field(name).query(text);
+        return builder;
+    }
+
+    static MultiMatchQuery.Builder multiMatchQuery(String text, List<String> name) {
+        final MultiMatchQuery.Builder builder = new MultiMatchQuery.Builder();
+        builder.fields(name).query(text);
+        return builder;
+    }
+
+    static Query.Builder convertBuilder(final NestedQuery.Builder nestedQueryBuilder){
+        Query.Builder builder = new Query.Builder();
+        builder.nested(nestedQueryBuilder.build());
+        return builder;
+    }
+
+    static Query.Builder convertBuilder(final MatchQuery.Builder matchQueryBuilder){
+        Query.Builder builder = new Query.Builder();
+        builder.match(matchQueryBuilder.build());
+        return builder;
+    }
+
+    static Query.Builder convertBuilder(final BoolQuery.Builder matchQueryBuilder){
+        Query.Builder builder = new Query.Builder();
+        builder.bool(matchQueryBuilder.build());
+        return builder;
+    }
+
+    static Query.Builder convertBuilder(final MultiMatchQuery.Builder multiMatchQueryBuilder){
+        Query.Builder builder = new Query.Builder();
+        builder.multiMatch(multiMatchQueryBuilder.build());
+        return builder;
+    }
+
+    static Query.Builder convertBuilder(final DisMaxQuery.Builder disMaxQueryBuilder){
+        Query.Builder builder = new Query.Builder();
+        builder.disMax(disMaxQueryBuilder.build());
+        return builder;
+    }
+
+    static Query.Builder convertBuilder(final TermsQuery.Builder termsQueryBuilder){
+        Query.Builder builder = new Query.Builder();
+        builder.terms(termsQueryBuilder.build());
+        return builder;
+    }
+
+    static Query.Builder convertBuilder(final RangeQuery.Builder rangeQueryBuilder){
+        Query.Builder builder = new Query.Builder();
+        builder.range(rangeQueryBuilder.build());
+        return builder;
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/ElasticSearchQueryBuilderCache.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/ElasticSearchQueryBuilderCache.java
@@ -102,9 +102,9 @@ import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps.Wi
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class ElasticSearchQueryBuilderCache {

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/AddressQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/AddressQueryBuilder.java
@@ -1,18 +1,22 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.elasticsearch.index.query.Operator.AND;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.matchQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class AddressQueryBuilder implements ElasticSearchQueryBuilder {
 
     private static final String ADDRESS_LINES = "parties.addressLines";
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
-        return matchQuery(ADDRESS_LINES, queryParams[0]).operator(AND);
+    public Query getQueryBuilderBy(final Object... queryParams) {
+        Query.Builder builder = new Query.Builder();
+        builder.match(matchQuery(ADDRESS_LINES, String.valueOf(queryParams[0])).operator(Operator.And).build());
+        return builder.build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ApplicationStatusQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ApplicationStatusQueryBuilder.java
@@ -1,17 +1,17 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.APPLICATIONS_STATUS_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class ApplicationStatusQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
-        return termQuery(APPLICATIONS_STATUS_PATH, valueOf(queryParams[0]));
+    public Query getQueryBuilderBy(final Object... queryParams) {
+        return termQuery(APPLICATIONS_STATUS_PATH, valueOf(queryParams[0])).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ApplicationTypeQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ApplicationTypeQueryBuilder.java
@@ -1,18 +1,19 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.APPLICATION_TYPE_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class ApplicationTypeQueryBuilder implements ElasticSearchQueryBuilder {
 
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
-        return termQuery(APPLICATION_TYPE_PATH, valueOf(queryParams[0]));
+    public Query getQueryBuilderBy(final Object... queryParams) {
+        return termQuery(APPLICATION_TYPE_PATH, valueOf(queryParams[0])).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ArrestSummonsNumberSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ArrestSummonsNumberSearchQueryBuilder.java
@@ -1,18 +1,19 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.PARTIES_ASN_REFERENCE_PATH;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class ArrestSummonsNumberSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String asnQueryParam = valueOf(queryParams[0]);
-        return termQuery(PARTIES_ASN_REFERENCE_PATH, asnQueryParam);
+        return termQuery(PARTIES_ASN_REFERENCE_PATH, asnQueryParam).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/BoxHearingQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/BoxHearingQueryBuilder.java
@@ -2,18 +2,19 @@ package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_BOX_HEARING_PATH;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class BoxHearingQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final boolean isBoxWork = parseBoolean(valueOf(queryParams[0]));
-        return termQuery(IS_BOX_HEARING_PATH, isBoxWork);
+        return termQuery(IS_BOX_HEARING_PATH, isBoxWork).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CaseStatusQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CaseStatusQueryBuilder.java
@@ -1,19 +1,19 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.CASE_STATUS_PARAM;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termsQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class CaseStatusQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String[] caseStatuses = clean(queryParams[0]);
-        return termsQuery(CASE_STATUS_PARAM, caseStatuses);
+        return termsQuery(CASE_STATUS_PARAM, caseStatuses).build();
     }
 
     @Override

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CourtOrderValidityDateQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CourtOrderValidityDateQueryBuilder.java
@@ -1,32 +1,43 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
+
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.COURT_ORDER_END_DATE_PATH;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.COURT_ORDER_START_DATE_PATH;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.RangeQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
+import co.elastic.clients.json.JsonData;
+
 
 public class CourtOrderValidityDateQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String courtOrderValidityDataQueryParam = valueOf(queryParams[0]);
 
-        return boolQuery()
-                .must(getRangeGTEBuilderQuery(courtOrderValidityDataQueryParam))
-                .must(getRangeLTEBuilderQuery(courtOrderValidityDataQueryParam));
+        return convertBuilder((new BoolQuery.Builder())
+                .must(getRangeGTEBuilderQuery(courtOrderValidityDataQueryParam).build())
+                .must(getRangeLTEBuilderQuery(courtOrderValidityDataQueryParam).build())).build();
     }
 
-    private RangeQueryBuilder getRangeGTEBuilderQuery(final String courtOrderValidityDataQueryParam) {
-        return rangeQuery(COURT_ORDER_START_DATE_PATH).lte(courtOrderValidityDataQueryParam);
+    private RangeQuery.Builder getRangeGTEBuilderQuery(final String courtOrderValidityDataQueryParam) {
+        RangeQuery.Builder builder = new RangeQuery.Builder();
+        builder.untyped( u -> u
+                .field(COURT_ORDER_START_DATE_PATH)
+                .lte(JsonData.of(courtOrderValidityDataQueryParam)));
+        return builder;
     }
 
-    private RangeQueryBuilder getRangeLTEBuilderQuery(final String courtOrderValidityDataQueryParam) {
-        return rangeQuery(COURT_ORDER_END_DATE_PATH).gte(courtOrderValidityDataQueryParam);
+    private RangeQuery.Builder getRangeLTEBuilderQuery(final String courtOrderValidityDataQueryParam) {
+        RangeQuery.Builder builder = new RangeQuery.Builder();
+        builder.untyped( u -> u
+                .field(COURT_ORDER_END_DATE_PATH)
+                .gte(JsonData.of(courtOrderValidityDataQueryParam)));
+        return builder;
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CourtSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CourtSearchQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.HEARING_DAY_COURTCENTRE_REFERENCE_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class CourtSearchQueryBuilder implements ElasticSearchQueryBuilder {
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String courtIdParam = valueOf(queryParams[0]);
 
-        return termQuery(HEARING_DAY_COURTCENTRE_REFERENCE_PATH, courtIdParam);
+        return termQuery(HEARING_DAY_COURTCENTRE_REFERENCE_PATH, courtIdParam).build();
 
    }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CroNumberSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CroNumberSearchQueryBuilder.java
@@ -1,18 +1,19 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.CRO_NUMBER_INDEX;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+
 
 public class CroNumberSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String croNumber = valueOf(queryParams[0]);
-        return termQuery(CRO_NUMBER_INDEX, croNumber);
+        return termQuery(CRO_NUMBER_INDEX, croNumber).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CrownOrMagistratesQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CrownOrMagistratesQueryBuilder.java
@@ -2,31 +2,32 @@ package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_CROWN_COURT;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_MAGISTRATE_COURT;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class CrownOrMagistratesQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final boolean crownOrMagistrates = parseBoolean(valueOf(queryParams[0]));
-        final BoolQueryBuilder booleanQueryBuilder = boolQuery();
+        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
 
         if (crownOrMagistrates) {
             /*should means: At least one of these clauses must match, like logical OR*/
-            booleanQueryBuilder.should(termQuery(IS_CROWN_COURT, true));
-            booleanQueryBuilder.should(termQuery(IS_MAGISTRATE_COURT, true));
+            booleanQueryBuilder.should(termQuery(IS_CROWN_COURT, true).build());
+            booleanQueryBuilder.should(termQuery(IS_MAGISTRATE_COURT, true).build());
         } else {
-            booleanQueryBuilder.must(termQuery(IS_CROWN_COURT, false));
-            booleanQueryBuilder.must(termQuery(IS_MAGISTRATE_COURT, false));
+            booleanQueryBuilder.must(termQuery(IS_CROWN_COURT, false).build());
+            booleanQueryBuilder.must(termQuery(IS_MAGISTRATE_COURT, false).build());
         }
-        return booleanQueryBuilder;
+        return convertBuilder(booleanQueryBuilder).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/DateOfBirthSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/DateOfBirthSearchQueryBuilder.java
@@ -1,18 +1,18 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.PARTIES_DATE_OF_BIRTH_REFERENCE_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class DateOfBirthSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String dateOfBirthQueryParam = valueOf(queryParams[0]);
-        return termQuery(PARTIES_DATE_OF_BIRTH_REFERENCE_PATH, dateOfBirthQueryParam);
+        return termQuery(PARTIES_DATE_OF_BIRTH_REFERENCE_PATH, dateOfBirthQueryParam).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/DefendantAddressLine1QueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/DefendantAddressLine1QueryBuilder.java
@@ -1,17 +1,19 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.elasticsearch.index.query.Operator.AND;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.matchQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.ADDRESS1_INDEX;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class DefendantAddressLine1QueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
-        return matchQuery(ADDRESS1_INDEX, queryParams[0]).operator(AND);
+    public Query getQueryBuilderBy(final Object... queryParams) {
+        final Query.Builder builder = new Query.Builder();
+        builder.match(matchQuery(ADDRESS1_INDEX, String.valueOf(queryParams[0])).operator(Operator.And).build());
+        return builder.build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstAndOrMiddleNameLeafQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstAndOrMiddleNameLeafQueryBuilder.java
@@ -36,6 +36,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType;
  * all words are searched for across all 2 fields so this will catch all permutations not catered
  * for above, e.g. lastName/firstName
  */
+@SuppressWarnings("common-java:DuplicatedBlocks")
 public class FirstAndOrMiddleNameLeafQueryBuilder {
 
     private static final String PARTY_FIRST_NAME_FIELD = "parties.firstName";
@@ -54,6 +55,7 @@ public class FirstAndOrMiddleNameLeafQueryBuilder {
     private static final List<String> allPartyAliasNamesFields = asList(PARTY_ALIAS_FIRST_NAME_FIELD, PARTY_ALIAS_MIDDLE_NAME_FIELD);
 
     private static final String FUZZINESS_AUTO = "AUTO";
+    public static final String F = "^2.0f";
     private final List<Query> additionalPartyQueryBuilders;
 
     private String allNames;
@@ -175,13 +177,13 @@ public class FirstAndOrMiddleNameLeafQueryBuilder {
     private MultiMatchQuery.Builder getMultiMatchQueryBuilderForParties() {
         if (hasOneName) {
             final MultiMatchQuery.Builder allNameFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, asList(PARTY_FIRST_NAME_FIELD));
-            allNameFieldsMultiMatchQuery.fields(PARTY_FIRST_NAME_FIELD+"^2.0f");
+            allNameFieldsMultiMatchQuery.fields(PARTY_FIRST_NAME_FIELD+ F);
             allNameFieldsMultiMatchQuery.boost(0.3F);
             return allNameFieldsMultiMatchQuery;
         } else {
             final MultiMatchQuery.Builder allNameFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, allPartyNamesFields);
-            allNameFieldsMultiMatchQuery.fields(PARTY_FIRST_NAME_FIELD+"^2.0f");
-            allNameFieldsMultiMatchQuery.fields(PARTY_MIDDLE_NAME_FIELD+"^2.0f");
+            allNameFieldsMultiMatchQuery.fields(PARTY_FIRST_NAME_FIELD+ F);
+            allNameFieldsMultiMatchQuery.fields(PARTY_MIDDLE_NAME_FIELD+ F);
             allNameFieldsMultiMatchQuery.boost(0.3F);
             return allNameFieldsMultiMatchQuery;
         }
@@ -192,13 +194,13 @@ public class FirstAndOrMiddleNameLeafQueryBuilder {
     private MultiMatchQuery.Builder getMultiMatchQueryBuilderForPartyAliases() {
         if (hasOneName) {
             final MultiMatchQuery.Builder partyAliasFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, asList(PARTY_FIRST_NAME_FIELD));
-            partyAliasFieldsMultiMatchQuery.fields(PARTY_ALIAS_FIRST_NAME_FIELD+"^2.0f");
+            partyAliasFieldsMultiMatchQuery.fields(PARTY_ALIAS_FIRST_NAME_FIELD+ F);
             partyAliasFieldsMultiMatchQuery.boost(0.3F);
             return partyAliasFieldsMultiMatchQuery;
         } else {
             final MultiMatchQuery.Builder partyAliasFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, allPartyAliasNamesFields);
-            partyAliasFieldsMultiMatchQuery.fields(PARTY_ALIAS_FIRST_NAME_FIELD+"^2.0f");
-            partyAliasFieldsMultiMatchQuery.fields(PARTY_ALIAS_MIDDLE_NAME_FIELD+"^2.0f");
+            partyAliasFieldsMultiMatchQuery.fields(PARTY_ALIAS_FIRST_NAME_FIELD+ F);
+            partyAliasFieldsMultiMatchQuery.fields(PARTY_ALIAS_MIDDLE_NAME_FIELD+ F);
             partyAliasFieldsMultiMatchQuery.boost(0.3F);
             return partyAliasFieldsMultiMatchQuery;
         }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstAndOrMiddleNameLeafQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstAndOrMiddleNameLeafQueryBuilder.java
@@ -82,8 +82,8 @@ public class FirstAndOrMiddleNameLeafQueryBuilder {
     public Query.Builder nestedPartiesBuilder() {
 
         final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(false).build());
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(true).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(false, getMustMatchQueryBuilderForPartiesList()).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(true, getMustMatchQueryBuilderForPartiesList()).build());
         booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForParties().operator(And).boost(0.4F))).build());
         booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForParties().operator(Or))).build());
 
@@ -97,8 +97,8 @@ public class FirstAndOrMiddleNameLeafQueryBuilder {
 
         final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
 
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForPartyAliases(false).build());
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForPartyAliases(true).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(false,getMustMatchQueryBuilderForPartyAliasesList()).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(true,getMustMatchQueryBuilderForPartyAliasesList()).build());
         booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForPartyAliases().operator(And).boost(0.4F))).build());
         booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForPartyAliases().operator(Or))).build());
 
@@ -110,12 +110,9 @@ public class FirstAndOrMiddleNameLeafQueryBuilder {
         return convertBuilder(nestedQuery(PARTY_NESTED_PATH, convertBuilder(partyAliasesNestedQueryBuilder)));
     }
 
-    private Query.Builder getMustMatchQueryBuilderForParties(final Boolean isFuzziness) {
+    private Query.Builder getMustMatchQueryBuilderForParties(final Boolean isFuzziness, final List<Query.Builder> mustMatchQueryBuilderList) {
         final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
-
         this.additionalPartyQueryBuilders.forEach( b-> booleanQueryBuilder.must(b));
-
-        final List<Query.Builder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartiesList();
         if (isFuzziness){
             mustMatchQueryBuilderList.stream()
                     .map(mqb -> mqb.build().match())
@@ -128,28 +125,6 @@ public class FirstAndOrMiddleNameLeafQueryBuilder {
             booleanQueryBuilder.boost(2.0F);
         } else {
             mustMatchQueryBuilderList.forEach(b -> booleanQueryBuilder.must(b.build()));
-
-            booleanQueryBuilder.boost(3.0F);
-        }
-        return convertBuilder(booleanQueryBuilder);
-    }
-
-    private Query.Builder getMustMatchQueryBuilderForPartyAliases(final boolean isFuzziness) {
-        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
-        this.additionalPartyQueryBuilders.forEach( b-> booleanQueryBuilder.must(b));
-        final List<Query.Builder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartyAliasesList();
-        if (isFuzziness){
-            mustMatchQueryBuilderList.stream()
-                    .map(q -> q.build().match())
-                    .forEach(mqb -> {
-                        final MatchQuery.Builder builder = QueryBuilderUtils.copyQuery(mqb);
-                        builder.fuzziness(FUZZINESS_AUTO);
-                        booleanQueryBuilder.must(builder.build());
-                    });
-            booleanQueryBuilder.boost(2.0F);
-        } else {
-            mustMatchQueryBuilderList.forEach(b -> booleanQueryBuilder.must(b.build()));
-
             booleanQueryBuilder.boost(3.0F);
         }
         return convertBuilder(booleanQueryBuilder);

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstAndOrMiddleNameSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstAndOrMiddleNameSearchQueryBuilder.java
@@ -1,39 +1,40 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.disMaxQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
 import java.util.List;
 
-import org.elasticsearch.index.query.DisMaxQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.DisMaxQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 //Not in use
 public class FirstAndOrMiddleNameSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... nameQueryParam) {
+    public Query getQueryBuilderBy(final Object... nameQueryParam) {
 
         final String allNames = valueOf(nameQueryParam[0]);
-        final List<QueryBuilder> additionalPartyQueryBuilders = (List<QueryBuilder>) nameQueryParam[1];
+        final List<Query> additionalPartyQueryBuilders = (List<Query>) nameQueryParam[1];
         final FirstAndOrMiddleNameLeafQueryBuilder nameLeafQueryBuilder = new FirstAndOrMiddleNameLeafQueryBuilder(allNames, additionalPartyQueryBuilders);
         return namesQueryCompositeBuilder(nameLeafQueryBuilder);
 
     }
 
-    private QueryBuilder namesQueryCompositeBuilder(final FirstAndOrMiddleNameLeafQueryBuilder firstAndOrMiddleNameLeafQueryBuilder) {
-        final DisMaxQueryBuilder disMaxQueryBuilder = disMaxQuery();
+    private Query namesQueryCompositeBuilder(final FirstAndOrMiddleNameLeafQueryBuilder firstAndOrMiddleNameLeafQueryBuilder) {
+        final DisMaxQuery.Builder disMaxQueryBuilder = new DisMaxQuery.Builder();
 
-        disMaxQueryBuilder.add(firstAndOrMiddleNameLeafQueryBuilder.nestedPartiesBuilder());
+        disMaxQueryBuilder.queries(firstAndOrMiddleNameLeafQueryBuilder.nestedPartiesBuilder().build());
 
-        disMaxQueryBuilder.add(firstAndOrMiddleNameLeafQueryBuilder.nestedPartyAliasesBuilder());
+        disMaxQueryBuilder.queries(firstAndOrMiddleNameLeafQueryBuilder.nestedPartyAliasesBuilder().build());
 
-        disMaxQueryBuilder.tieBreaker(0.0F);
+        disMaxQueryBuilder.tieBreaker(0.0);
         disMaxQueryBuilder.boost(1.2F);
 
-        return disMaxQueryBuilder;
+        return convertBuilder(disMaxQueryBuilder).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstNameSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstNameSearchQueryBuilder.java
@@ -1,18 +1,19 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.FIRST_NAME_INDEX;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class FirstNameSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String firstName = valueOf(queryParams[0]);
-        return termQuery(FIRST_NAME_INDEX, firstName);
+        return termQuery(FIRST_NAME_INDEX, firstName).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HasOffenceQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HasOffenceQueryBuilder.java
@@ -2,29 +2,30 @@ package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.valueOf;
-import static org.apache.lucene.search.join.ScoreMode.Avg;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
-import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.OFFENCES_NESTED_PATH;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.nestedQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ExistsQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class HasOffenceQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final boolean hasOffence = parseBoolean(valueOf(queryParams[0]));
-        final BoolQueryBuilder offencesInnerBoolWrapper = boolQuery();
-
+        final BoolQuery.Builder offencesInnerBoolWrapper =new BoolQuery.Builder();
+        final ExistsQuery.Builder existsQueryBuilder = new ExistsQuery.Builder();
         if (hasOffence) {
-            offencesInnerBoolWrapper.must(existsQuery(OFFENCES_NESTED_PATH));
+            offencesInnerBoolWrapper.must(existsQueryBuilder.field(OFFENCES_NESTED_PATH).build());
         } else {
-            offencesInnerBoolWrapper.mustNot(existsQuery(OFFENCES_NESTED_PATH));
+            offencesInnerBoolWrapper.mustNot(existsQueryBuilder.field(OFFENCES_NESTED_PATH).build());
         }
-        return nestedQuery(OFFENCES_NESTED_PATH, offencesInnerBoolWrapper, Avg);
+        final Query.Builder queryBuilder = new Query.Builder();
+        queryBuilder.bool(offencesInnerBoolWrapper.build());
+        return convertBuilder(nestedQuery(OFFENCES_NESTED_PATH,  queryBuilder)).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingDateSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingDateSearchQueryBuilder.java
@@ -1,41 +1,47 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-import static uk.gov.moj.cpp.unifiedsearch.query.builders.utils.HearingDateUtil.stringToDate;
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.HEARING_DAY_REFERENCE_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.RangeQueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
+import co.elastic.clients.json.JsonData;
+
 
 public class HearingDateSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String hearingDateFromQueryParam = valueOf(queryParams[0]);
         final String hearingDateToQueryParam = valueOf(queryParams[1]);
 
         if (!hearingDateFromQueryParam.isEmpty() && hearingDateToQueryParam.isEmpty()) {
-            return getTermBuilderQuery(hearingDateFromQueryParam);
+            return getTermBuilderQuery(hearingDateFromQueryParam).build();
 
         }
 
         if (!hearingDateToQueryParam.isEmpty() && hearingDateFromQueryParam.isEmpty()) {
-            return getTermBuilderQuery(hearingDateToQueryParam);
+            return getTermBuilderQuery(hearingDateToQueryParam).build();
         }
 
-        return getRangeBuilderQuery(hearingDateFromQueryParam, hearingDateToQueryParam);
+        return convertBuilder(getRangeBuilderQuery(hearingDateFromQueryParam, hearingDateToQueryParam)).build();
     }
 
-    private RangeQueryBuilder getRangeBuilderQuery(final String hearingDateFromQueryParam, final String hearingDateToQueryParam) {
-        return rangeQuery(HEARING_DAY_REFERENCE_PATH).from(stringToDate(hearingDateFromQueryParam)).to(stringToDate(hearingDateToQueryParam));
+    private RangeQuery.Builder getRangeBuilderQuery(final String hearingDateFromQueryParam, final String hearingDateToQueryParam) {
+        RangeQuery.Builder builder = new RangeQuery.Builder();
+        builder.untyped( u -> u
+                .field(HEARING_DAY_REFERENCE_PATH)
+                .gte(JsonData.of(hearingDateFromQueryParam))
+                .lte(JsonData.of(hearingDateToQueryParam)));
+        return builder;
     }
 
-    private TermQueryBuilder getTermBuilderQuery(final String queryParam) {
+    private Query.Builder getTermBuilderQuery(final String queryParam) {
         return termQuery(HEARING_DAY_REFERENCE_PATH, queryParam);
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingIdQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingIdQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.HEARING_ID_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class HearingIdQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String hearingType = valueOf(queryParams[0]);
-        return termQuery(HEARING_ID_PATH, hearingType);
+        return termQuery(HEARING_ID_PATH, hearingType).build();
 
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingTypeQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingTypeQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.HEARING_TYPE_ID_PATH;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class HearingTypeQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String hearingType = valueOf(queryParams[0]);
-        return termQuery(HEARING_TYPE_ID_PATH, hearingType);
+        return termQuery(HEARING_TYPE_ID_PATH, hearingType).build();
 
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/JurisdictionTypeQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/JurisdictionTypeQueryBuilder.java
@@ -2,37 +2,38 @@ package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_CROWN_COURT;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_MAGISTRATE_COURT;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_SJP;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class JurisdictionTypeQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final boolean sjp = parseBoolean(valueOf(queryParams[0]));
         final boolean magistrateCourt = parseBoolean(valueOf(queryParams[1]));
         final boolean crownCourt = parseBoolean(valueOf(queryParams[2]));
 
-        final BoolQueryBuilder booleanQueryBuilder = boolQuery();
+        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
 
         addShouldClauseIfParamPresentAndTrue(IS_SJP, sjp, booleanQueryBuilder);
         addShouldClauseIfParamPresentAndTrue(IS_MAGISTRATE_COURT, magistrateCourt, booleanQueryBuilder);
         addShouldClauseIfParamPresentAndTrue(IS_CROWN_COURT, crownCourt, booleanQueryBuilder);
 
-        return booleanQueryBuilder;
+        return convertBuilder(booleanQueryBuilder).build();
     }
 
-    private void addShouldClauseIfParamPresentAndTrue(final String fieldName, final boolean queryParam, final BoolQueryBuilder boolQueryBuilder){
+    private void addShouldClauseIfParamPresentAndTrue(final String fieldName, final boolean queryParam, final BoolQuery.Builder boolQueryBuilder){
         if (queryParam) {
-            boolQueryBuilder.should(termQuery(fieldName, true));
+            boolQueryBuilder.should(termQuery(fieldName, true).build());
         }
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastNameSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastNameSearchQueryBuilder.java
@@ -1,17 +1,18 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.LAST_NAME_INDEX;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class LastNameSearchQueryBuilder implements ElasticSearchQueryBuilder {
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String lastName = valueOf(queryParams[0]);
-        return termQuery(LAST_NAME_INDEX, lastName);
+        return termQuery(LAST_NAME_INDEX, lastName).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastOrOrganisationNameLeafQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastOrOrganisationNameLeafQueryBuilder.java
@@ -36,6 +36,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType;
  * all words are searched for across all 2 fields so this will catch all permutations not catered
  * for above, e.g. lastName/lastName
  */
+@SuppressWarnings("common-java:DuplicatedBlocks")
 public class LastOrOrganisationNameLeafQueryBuilder {
 
     private static final String PARTY_LAST_NAME_FIELD = "parties.lastName";
@@ -53,6 +54,7 @@ public class LastOrOrganisationNameLeafQueryBuilder {
     private static final List<String> allPartyAliasNamesFields = asList(PARTY_ALIAS_LAST_NAME_FIELD, PARTY_ALIAS_ORGANISATION_NAME_FIELD);
 
     private static final String FUZZINESS_AUTO = "AUTO";
+    public static final String F = "^2.0f";
     private final List<Query> additionalPartyQueryBuilders;
 
     private String allNames;
@@ -158,16 +160,16 @@ public class LastOrOrganisationNameLeafQueryBuilder {
 
     private MultiMatchQuery.Builder getMultiMatchQueryBuilderForParties() {
         final MultiMatchQuery.Builder allNameFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, allPartyNamesFields);
-        allNameFieldsMultiMatchQuery.fields(PARTY_LAST_NAME_FIELD+"^2.0f");
-        allNameFieldsMultiMatchQuery.fields(PARTY_ORGANISATION_NAME_FIELD+"^2.0f");
+        allNameFieldsMultiMatchQuery.fields(PARTY_LAST_NAME_FIELD+ F);
+        allNameFieldsMultiMatchQuery.fields(PARTY_ORGANISATION_NAME_FIELD+ F);
         allNameFieldsMultiMatchQuery.boost(0.3F);
         return allNameFieldsMultiMatchQuery;
     }
 
     private MultiMatchQuery.Builder getMultiMatchQueryBuilderForPartyAliases() {
         final MultiMatchQuery.Builder partyAliasFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, allPartyAliasNamesFields);
-        partyAliasFieldsMultiMatchQuery.fields(PARTY_ALIAS_LAST_NAME_FIELD+"^2.0f");
-        partyAliasFieldsMultiMatchQuery.fields(PARTY_ALIAS_ORGANISATION_NAME_FIELD+"^2.0f");
+        partyAliasFieldsMultiMatchQuery.fields(PARTY_ALIAS_LAST_NAME_FIELD+ F);
+        partyAliasFieldsMultiMatchQuery.fields(PARTY_ALIAS_ORGANISATION_NAME_FIELD+ F);
         partyAliasFieldsMultiMatchQuery.boost(0.3F);
         return partyAliasFieldsMultiMatchQuery;
     }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastOrOrganisationNameLeafQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastOrOrganisationNameLeafQueryBuilder.java
@@ -68,8 +68,8 @@ public class LastOrOrganisationNameLeafQueryBuilder {
     public Query.Builder nestedPartiesBuilder() {
 
         final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(false).build());
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(true).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(false, getMustMatchQueryBuilderForPartiesList()).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(true, getMustMatchQueryBuilderForPartiesList()).build());
         booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForParties().operator(Operator.Or))).build());
 
         final List<Query.Builder> prefixQueryBuilderList = getMatchNgramQueryBuilderForPartiesList();
@@ -82,8 +82,8 @@ public class LastOrOrganisationNameLeafQueryBuilder {
 
         final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
 
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForPartyAliases(false).build());
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForPartyAliases(true).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(false, getMustMatchQueryBuilderForPartyAliasesList()).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(true, getMustMatchQueryBuilderForPartyAliasesList()).build());
         booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForPartyAliases().operator(Operator.Or))).build());
 
         final List<Query.Builder> prefixQueryBuilderList = getMatchNgramQueryBuilderForPartyAliasesList();
@@ -94,12 +94,11 @@ public class LastOrOrganisationNameLeafQueryBuilder {
         return convertBuilder(nestedQuery(PARTY_NESTED_PATH, convertBuilder(partyAliasesNestedQueryBuilder)));
     }
 
-    private Query.Builder getMustMatchQueryBuilderForParties(final boolean isFuzziness) {
+    private Query.Builder getMustMatchQueryBuilderForParties(final boolean isFuzziness, final List<Query.Builder> mustMatchQueryBuilderList) {
         final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
 
         this.additionalPartyQueryBuilders.forEach(b -> booleanQueryBuilder.must(b));
 
-        final List<Query.Builder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartiesList();
         if(isFuzziness){
             mustMatchQueryBuilderList.stream()
                     .map(q -> q.build().match())
@@ -109,26 +108,6 @@ public class LastOrOrganisationNameLeafQueryBuilder {
                         booleanQueryBuilder.must(builder.build());
                     });
 
-            booleanQueryBuilder.boost(2.0F);
-        }else {
-            mustMatchQueryBuilderList.forEach(b -> booleanQueryBuilder.must(b.build()));
-            booleanQueryBuilder.boost(3.0F);
-        }
-        return convertBuilder(booleanQueryBuilder);
-    }
-
-    private Query.Builder getMustMatchQueryBuilderForPartyAliases(final boolean isFuzziness) {
-        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
-        this.additionalPartyQueryBuilders.forEach( b-> booleanQueryBuilder.must(b));
-        final List<Query.Builder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartyAliasesList();
-        if(isFuzziness){
-            mustMatchQueryBuilderList.stream()
-                    .map(q -> q.build().match())
-                    .forEach(mqb -> {
-                        final MatchQuery.Builder builder = QueryBuilderUtils.copyQuery(mqb);
-                        builder.fuzziness(FUZZINESS_AUTO);
-                        booleanQueryBuilder.must(builder.build());
-                    });
             booleanQueryBuilder.boost(2.0F);
         }else {
             mustMatchQueryBuilderList.forEach(b -> booleanQueryBuilder.must(b.build()));

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastOrOrganisationNameSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastOrOrganisationNameSearchQueryBuilder.java
@@ -1,39 +1,38 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.disMaxQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
 import java.util.List;
 
-import org.elasticsearch.index.query.DisMaxQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.DisMaxQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 //Not in use
 public class LastOrOrganisationNameSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... nameQueryParam) {
+    public Query getQueryBuilderBy(final Object... nameQueryParam) {
 
         final String allNames = valueOf(nameQueryParam[0]);
-        final List<QueryBuilder> additionalPartyQueryBuilders = (List<QueryBuilder>) nameQueryParam[1];
+        final List<Query> additionalPartyQueryBuilders = (List<Query>) nameQueryParam[1];
         final LastOrOrganisationNameLeafQueryBuilder lastOrOrganisationNameLeafQueryBuilder = new LastOrOrganisationNameLeafQueryBuilder(allNames, additionalPartyQueryBuilders);
-        final QueryBuilder queryBuilder = namesQueryCompositeBuilder(lastOrOrganisationNameLeafQueryBuilder);
-        return queryBuilder;
+        return namesQueryCompositeBuilder(lastOrOrganisationNameLeafQueryBuilder);
     }
 
-    private QueryBuilder namesQueryCompositeBuilder(final LastOrOrganisationNameLeafQueryBuilder lastOrOrganisationNameLeafQueryBuilder) {
-        final DisMaxQueryBuilder disMaxQueryBuilder = disMaxQuery();
+    private Query namesQueryCompositeBuilder(final LastOrOrganisationNameLeafQueryBuilder lastOrOrganisationNameLeafQueryBuilder) {
+        final DisMaxQuery.Builder disMaxQueryBuilder = new DisMaxQuery.Builder();
 
-        disMaxQueryBuilder.add(lastOrOrganisationNameLeafQueryBuilder.nestedPartiesBuilder());
+        disMaxQueryBuilder.queries(lastOrOrganisationNameLeafQueryBuilder.nestedPartiesBuilder().build());
 
-        disMaxQueryBuilder.add(lastOrOrganisationNameLeafQueryBuilder.nestedPartyAliasesBuilder());
+        disMaxQueryBuilder.queries(lastOrOrganisationNameLeafQueryBuilder.nestedPartyAliasesBuilder().build());
 
-        disMaxQueryBuilder.tieBreaker(0.0F);
+        disMaxQueryBuilder.tieBreaker(0.0);
         disMaxQueryBuilder.boost(1.2F);
 
-        return disMaxQueryBuilder;
+        return convertBuilder(disMaxQueryBuilder).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NameLeafQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NameLeafQueryBuilder.java
@@ -39,6 +39,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Query;
  * all words are searched for across all 4 fields so this will catch all permutations not catered
  * for above, e.g. lastName/firstName
  */
+@SuppressWarnings("common-java:DuplicatedBlocks")
 public class NameLeafQueryBuilder {
 
     private static final String PARTY_FIRST_NAME_FIELD = "parties.firstName";
@@ -63,6 +64,7 @@ public class NameLeafQueryBuilder {
     private static final List<String> lastNameAndOrganisationNameAliasFields = asList(PARTY_ALIAS_LAST_NAME_FIELD, PARTY_ALIAS_ORGANISATION_NAME_FIELD);
 
     private static final String FUZZINESS_AUTO = "AUTO";
+    public static final String F = "^2.0f";
     private final List<Query> additionalPartyQueryBuilders;
 
     private String allNames;
@@ -272,8 +274,8 @@ public class NameLeafQueryBuilder {
         }
         final MultiMatchQuery.Builder allNameFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, fields);
         if (hasOneName) {
-            allNameFieldsMultiMatchQuery.fields(PARTY_LAST_NAME_FIELD+"^2.0f");
-            allNameFieldsMultiMatchQuery.fields(PARTY_ORGANISATION_NAME_FIELD+"^2.0f");
+            allNameFieldsMultiMatchQuery.fields(PARTY_LAST_NAME_FIELD+ F);
+            allNameFieldsMultiMatchQuery.fields(PARTY_ORGANISATION_NAME_FIELD+ F);
         }
 
         allNameFieldsMultiMatchQuery.boost(0.3F);
@@ -300,7 +302,7 @@ public class NameLeafQueryBuilder {
         }
         final MultiMatchQuery.Builder partyAliasFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, fields);
         if (hasOneName) {
-            partyAliasFieldsMultiMatchQuery.fields(asList(PARTY_ALIAS_LAST_NAME_FIELD+"^2.0f",PARTY_ALIAS_ORGANISATION_NAME_FIELD+"^2.0f" ));
+            partyAliasFieldsMultiMatchQuery.fields(asList(PARTY_ALIAS_LAST_NAME_FIELD+ F,PARTY_ALIAS_ORGANISATION_NAME_FIELD+ F));
         }
 
         partyAliasFieldsMultiMatchQuery.boost(0.3F);

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NameLeafQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NameLeafQueryBuilder.java
@@ -1,27 +1,25 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
+import static co.elastic.clients.elasticsearch._types.query_dsl.Operator.And;
+import static co.elastic.clients.elasticsearch._types.query_dsl.Operator.Or;
 import static com.google.common.collect.ImmutableList.of;
 import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.elasticsearch.index.query.MultiMatchQueryBuilder.Type.CROSS_FIELDS;
-import static org.elasticsearch.index.query.Operator.AND;
-import static org.elasticsearch.index.query.Operator.OR;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
-import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
-import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.matchQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.nestedQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.PARTY_NESTED_PATH;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.lucene.search.join.ScoreMode;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.NestedQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MultiMatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 /**
  * The nameQueryParam passed to {@link #NameLeafQueryBuilder(String, List)} can contain any number
@@ -65,7 +63,7 @@ public class NameLeafQueryBuilder {
     private static final List<String> lastNameAndOrganisationNameAliasFields = asList(PARTY_ALIAS_LAST_NAME_FIELD, PARTY_ALIAS_ORGANISATION_NAME_FIELD);
 
     private static final String FUZZINESS_AUTO = "AUTO";
-    private final List<QueryBuilder> additionalPartyQueryBuilders;
+    private final List<Query> additionalPartyQueryBuilders;
 
     private String allNames;
     private String firstName;
@@ -81,7 +79,7 @@ public class NameLeafQueryBuilder {
      */
     private boolean inSingleNameFieldMode = true;
 
-    public NameLeafQueryBuilder(final String allNames, final List<QueryBuilder> additionalPartyQueryBuilders) {
+    public NameLeafQueryBuilder(final String allNames, final List<Query> additionalPartyQueryBuilders) {
 
         this.additionalPartyQueryBuilders = additionalPartyQueryBuilders == null ? of() : additionalPartyQueryBuilders;
 
@@ -104,7 +102,7 @@ public class NameLeafQueryBuilder {
         }
     }
 
-    public NameLeafQueryBuilder(final String partyFirstAndOrMiddleName, final String partyLastNameOrOrganisationName, final List<QueryBuilder> additionalPartyQueryBuilders) {
+    public NameLeafQueryBuilder(final String partyFirstAndOrMiddleName, final String partyLastNameOrOrganisationName, final List<Query> additionalPartyQueryBuilders) {
         this.additionalPartyQueryBuilders = additionalPartyQueryBuilders == null ? of() : additionalPartyQueryBuilders;
         inSingleNameFieldMode = false;
         firstName = EMPTY;
@@ -132,64 +130,64 @@ public class NameLeafQueryBuilder {
     }
 
 
-    public QueryBuilder nestedPartiesBuilder() {
+    public Query.Builder nestedPartiesBuilder() {
 
-        final BoolQueryBuilder booleanQueryBuilder = boolQuery();
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties());
-        booleanQueryBuilder.should(getMustMatchWithFuzzinessQueryBuilderForParties());
+        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties().build());
+        booleanQueryBuilder.should(getMustMatchWithFuzzinessQueryBuilderForParties().build());
         if (!allNames.isEmpty()) {
-            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(getMultiMatchQueryBuilderForParties().operator(AND).boost(0.4F)));
-            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(getMultiMatchQueryBuilderForParties().operator(OR)));
+            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForParties().operator(And).boost(0.4F))).build());
+            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForParties().operator(Or))).build());
         }
 
         if (!inSingleNameFieldMode && !firstName.isEmpty() && !middleName.isEmpty()) {
-            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(getMultiMatchQueryBuilderForFirstAndMiddleName().operator(AND).boost(0.1F)));
-            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(getMultiMatchQueryBuilderForFirstAndMiddleName().operator(OR)));
+            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForFirstAndMiddleName().operator(And).boost(0.1F))).build());
+            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForFirstAndMiddleName().operator(Or))).build());
         }
 
-        final List<QueryBuilder> prefixQueryBuilderList = getMatchNgramQueryBuilderForPartiesList();
+        final List<Query.Builder> prefixQueryBuilderList = getMatchNgramQueryBuilderForPartiesList();
         if (enableORQuery()) {
-            prefixQueryBuilderList.forEach(queryBuilder -> booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(queryBuilder)));
+            prefixQueryBuilderList.forEach(queryBuilder -> booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(queryBuilder).build()));
         } else {
-            prefixQueryBuilderList.forEach(queryBuilder -> booleanQueryBuilder.must(wrapWithAdditionalPartyQueryBuilders(queryBuilder)));
+            prefixQueryBuilderList.forEach(queryBuilder -> booleanQueryBuilder.must(wrapWithAdditionalPartyQueryBuilders(queryBuilder).build()));
         }
 
-        final MatchQueryBuilder organisationMatchBuilder = matchQueryBuilder(organisationName, PARTY_ORGANISATION_NAME_FIELD);
+        final MatchQuery.Builder organisationMatchBuilder = matchQueryBuilder(organisationName, PARTY_ORGANISATION_NAME_FIELD);
         organisationMatchBuilder.fuzziness(FUZZINESS_AUTO);
         organisationMatchBuilder.boost(2.0f);
 
-        booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(organisationMatchBuilder));
+        booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(organisationMatchBuilder)).build());
 
-        return nestedQuery(PARTY_NESTED_PATH, booleanQueryBuilder, ScoreMode.Avg);
+        return convertBuilder(nestedQuery(PARTY_NESTED_PATH, convertBuilder(booleanQueryBuilder)));
     }
 
-    public QueryBuilder nestedPartyAliasesBuilder() {
+    public Query.Builder nestedPartyAliasesBuilder() {
 
-        final BoolQueryBuilder booleanQueryBuilder = boolQuery();
+        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
 
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForPartyAliases());
-        booleanQueryBuilder.should(getMustMatchWithFuzzinessQueryBuilderForPartyAliases());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForPartyAliases().build());
+        booleanQueryBuilder.should(getMustMatchWithFuzzinessQueryBuilderForPartyAliases().build());
 
         if (!allNames.isEmpty()) {
-            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(getMultiMatchQueryBuilderForPartyAliases().operator(AND).boost(0.4F)));
-            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(getMultiMatchQueryBuilderForPartyAliases().operator(OR)));
+            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForPartyAliases().operator(And).boost(0.4F))).build());
+            booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForPartyAliases().operator(Or))).build());
         }
 
-        final List<QueryBuilder> prefixQueryBuilderList = getMatchNgramQueryBuilderForPartyAliasesList();
+        final List<Query.Builder> prefixQueryBuilderList = getMatchNgramQueryBuilderForPartyAliasesList();
         if (enableORQuery()) {
-            prefixQueryBuilderList.forEach(queryBuilder -> booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(queryBuilder)));
+            prefixQueryBuilderList.forEach(queryBuilder -> booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(queryBuilder).build()));
         } else {
-            prefixQueryBuilderList.forEach(queryBuilder -> booleanQueryBuilder.must(wrapWithAdditionalPartyQueryBuilders(queryBuilder)));
+            prefixQueryBuilderList.forEach(queryBuilder -> booleanQueryBuilder.must(wrapWithAdditionalPartyQueryBuilders(queryBuilder).build()));
         }
 
-        final MatchQueryBuilder organisationMatchBuilder = matchQueryBuilder(organisationName, PARTY_ALIAS_ORGANISATION_NAME_FIELD);
+        final MatchQuery.Builder organisationMatchBuilder = matchQueryBuilder(organisationName, PARTY_ALIAS_ORGANISATION_NAME_FIELD);
         organisationMatchBuilder.fuzziness(FUZZINESS_AUTO);
         organisationMatchBuilder.boost(2.0f);
-        booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(organisationMatchBuilder));
+        booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(organisationMatchBuilder)).build());
 
-        final NestedQueryBuilder partyAliasesNestedQueryBuilder = nestedQuery(PARTY_ALIAS_NESTED_PATH, booleanQueryBuilder, ScoreMode.Avg);
+        final NestedQuery.Builder partyAliasesNestedQueryBuilder = nestedQuery(PARTY_ALIAS_NESTED_PATH, convertBuilder(booleanQueryBuilder));
 
-        return nestedQuery(PARTY_NESTED_PATH, partyAliasesNestedQueryBuilder, ScoreMode.Avg);
+        return convertBuilder(nestedQuery(PARTY_NESTED_PATH, convertBuilder(partyAliasesNestedQueryBuilder)));
     }
 
     private boolean enableORQuery() {
@@ -197,73 +195,85 @@ public class NameLeafQueryBuilder {
     }
 
 
-    private QueryBuilder getMustMatchQueryBuilderForParties() {
-        final BoolQueryBuilder booleanQueryBuilder = boolQuery();
+    private Query.Builder getMustMatchQueryBuilderForParties() {
+        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
 
         this.additionalPartyQueryBuilders.forEach(booleanQueryBuilder::must);
 
-        final List<QueryBuilder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartiesList();
-        mustMatchQueryBuilderList.forEach(booleanQueryBuilder::must);
+        final List<Query.Builder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartiesList();
+        mustMatchQueryBuilderList.forEach(b -> booleanQueryBuilder.must(b.build()));
 
         booleanQueryBuilder.boost(3.0F);
 
-        return booleanQueryBuilder;
+        return convertBuilder(booleanQueryBuilder);
     }
 
-    private QueryBuilder getMustMatchWithFuzzinessQueryBuilderForParties() {
-        final BoolQueryBuilder booleanQueryBuilder = boolQuery();
+    private Query.Builder getMustMatchWithFuzzinessQueryBuilderForParties() {
+        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
         this.additionalPartyQueryBuilders.forEach(booleanQueryBuilder::must);
 
-        final List<QueryBuilder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartiesList();
+        final List<Query.Builder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartiesList();
 
         mustMatchQueryBuilderList.stream()
-                .map(MatchQueryBuilder.class::cast)
+                .map(q -> q.build().match())
                 .forEach(mqb -> {
-                    mqb.fuzziness(FUZZINESS_AUTO);
-                    booleanQueryBuilder.must(mqb);
+                    MatchQuery.Builder builder = new MatchQuery.Builder();
+                    builder.field(mqb.field());
+                    builder.query(mqb.query());
+                    builder.boost(mqb.boost());
+                    builder.fuzziness(FUZZINESS_AUTO);
+                    booleanQueryBuilder.must(builder.build());
                 });
 
         booleanQueryBuilder.boost(2.0F);
 
-        return booleanQueryBuilder;
+        return convertBuilder(booleanQueryBuilder);
     }
 
-    private QueryBuilder getMustMatchQueryBuilderForPartyAliases() {
-        final BoolQueryBuilder booleanQueryBuilder = boolQuery();
+    private Query.Builder getMustMatchQueryBuilderForPartyAliases() {
+        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
         this.additionalPartyQueryBuilders.forEach(booleanQueryBuilder::must);
-        final List<QueryBuilder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartyAliasesList();
-        mustMatchQueryBuilderList.forEach(booleanQueryBuilder::must);
+        final List<Query.Builder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartyAliasesList();
+        mustMatchQueryBuilderList.forEach(b -> booleanQueryBuilder.must(b.build()));
 
         booleanQueryBuilder.boost(3.0F);
 
-        return booleanQueryBuilder;
+        return convertBuilder(booleanQueryBuilder);
     }
 
-    private QueryBuilder getMustMatchWithFuzzinessQueryBuilderForPartyAliases() {
-        final BoolQueryBuilder booleanQueryBuilder = boolQuery();
+    private Query.Builder getMustMatchWithFuzzinessQueryBuilderForPartyAliases() {
+        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
         this.additionalPartyQueryBuilders.forEach(booleanQueryBuilder::must);
-        final List<QueryBuilder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartyAliasesList();
+        final List<Query.Builder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartyAliasesList();
 
         mustMatchQueryBuilderList.stream()
-                .map(MatchQueryBuilder.class::cast)
+                .map(q -> q.build().match())
                 .forEach(mqb -> {
-                    mqb.fuzziness(FUZZINESS_AUTO);
-                    booleanQueryBuilder.must(mqb);
+                    MatchQuery.Builder builder = new MatchQuery.Builder();
+                    builder.field(mqb.field());
+                    builder.query(mqb.query());
+                    builder.boost(mqb.boost());
+                    builder.fuzziness(FUZZINESS_AUTO);
+                    booleanQueryBuilder.must(builder.build());
                 });
 
 
         booleanQueryBuilder.boost(2.0F);
 
-        return booleanQueryBuilder;
+        return convertBuilder(booleanQueryBuilder);
     }
 
 
-    private MultiMatchQueryBuilder getMultiMatchQueryBuilderForParties() {
-        final List<String> fields = inSingleNameFieldMode ? allPartyNamesFields : lastNameAndOrganisationNameFields;
-        final MultiMatchQueryBuilder allNameFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, fields);
+    private MultiMatchQuery.Builder getMultiMatchQueryBuilderForParties() {
+        List<String> fields = inSingleNameFieldMode ? allPartyNamesFields : lastNameAndOrganisationNameFields;
+
+        if (hasOneName){
+            fields = fields.stream().filter(v -> !v.equals(PARTY_LAST_NAME_FIELD) && !v.equals(PARTY_ORGANISATION_NAME_FIELD) ).toList();
+        }
+        final MultiMatchQuery.Builder allNameFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, fields);
         if (hasOneName) {
-            allNameFieldsMultiMatchQuery.field(PARTY_LAST_NAME_FIELD, 2.0f);
-            allNameFieldsMultiMatchQuery.field(PARTY_ORGANISATION_NAME_FIELD, 2.0f);
+            allNameFieldsMultiMatchQuery.fields(PARTY_LAST_NAME_FIELD+"^2.0f");
+            allNameFieldsMultiMatchQuery.fields(PARTY_ORGANISATION_NAME_FIELD+"^2.0f");
         }
 
         allNameFieldsMultiMatchQuery.boost(0.3F);
@@ -272,10 +282,10 @@ public class NameLeafQueryBuilder {
         return allNameFieldsMultiMatchQuery;
     }
 
-    private MultiMatchQueryBuilder getMultiMatchQueryBuilderForFirstAndMiddleName() {
-        final MultiMatchQueryBuilder allNameFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(partyFirstAndOrMiddleName, firstAndMiddleNameFields);
+    private MultiMatchQuery.Builder getMultiMatchQueryBuilderForFirstAndMiddleName() {
+        final MultiMatchQuery.Builder allNameFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(partyFirstAndOrMiddleName, firstAndMiddleNameFields);
 
-        allNameFieldsMultiMatchQuery.field(PARTY_FIRST_NAME_FIELD, 1.10f);
+        allNameFieldsMultiMatchQuery.fields(PARTY_FIRST_NAME_FIELD+"^1.10f");
 
         allNameFieldsMultiMatchQuery.boost(0.3F);
 
@@ -283,12 +293,14 @@ public class NameLeafQueryBuilder {
         return allNameFieldsMultiMatchQuery;
     }
 
-    private MultiMatchQueryBuilder getMultiMatchQueryBuilderForPartyAliases() {
-        final List<String> fields = inSingleNameFieldMode ? allPartyAliasNamesFields : lastNameAndOrganisationNameAliasFields;
-        final MultiMatchQueryBuilder partyAliasFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, fields);
+    private MultiMatchQuery.Builder getMultiMatchQueryBuilderForPartyAliases() {
+        List<String> fields = inSingleNameFieldMode ? allPartyAliasNamesFields : lastNameAndOrganisationNameAliasFields;
         if (hasOneName) {
-            partyAliasFieldsMultiMatchQuery.field(PARTY_ALIAS_LAST_NAME_FIELD, 2.0f);
-            partyAliasFieldsMultiMatchQuery.field(PARTY_ALIAS_ORGANISATION_NAME_FIELD, 2.0f);
+            fields = fields.stream().filter(v -> !PARTY_ALIAS_LAST_NAME_FIELD.equals(v) && !PARTY_ALIAS_ORGANISATION_NAME_FIELD.equals(v)).toList();
+        }
+        final MultiMatchQuery.Builder partyAliasFieldsMultiMatchQuery = crossFieldsMultiMatchQueryBuilder(allNames, fields);
+        if (hasOneName) {
+            partyAliasFieldsMultiMatchQuery.fields(asList(PARTY_ALIAS_LAST_NAME_FIELD+"^2.0f",PARTY_ALIAS_ORGANISATION_NAME_FIELD+"^2.0f" ));
         }
 
         partyAliasFieldsMultiMatchQuery.boost(0.3F);
@@ -296,7 +308,7 @@ public class NameLeafQueryBuilder {
         return partyAliasFieldsMultiMatchQuery;
     }
 
-    private List<QueryBuilder> getMustMatchQueryBuilderForPartiesList() {
+    private List<Query.Builder> getMustMatchQueryBuilderForPartiesList() {
 
         return getMustMatchQueryBuilderList(PARTY_FIRST_NAME_FIELD,
                 PARTY_MIDDLE_NAME_FIELD,
@@ -305,7 +317,7 @@ public class NameLeafQueryBuilder {
 
     }
 
-    private List<QueryBuilder> getMustMatchQueryBuilderForPartyAliasesList() {
+    private List<Query.Builder> getMustMatchQueryBuilderForPartyAliasesList() {
 
         return getMustMatchQueryBuilderList(PARTY_ALIAS_FIRST_NAME_FIELD,
                 PARTY_ALIAS_MIDDLE_NAME_FIELD,
@@ -314,7 +326,7 @@ public class NameLeafQueryBuilder {
 
     }
 
-    private List<QueryBuilder> getMatchNgramQueryBuilderForPartiesList() {
+    private List<Query.Builder> getMatchNgramQueryBuilderForPartiesList() {
 
         return getMatchNgramQueryBuilderList(PARTY_FIRST_NAME_NGRAM_FIELD,
                 PARTY_LAST_NAME_NGRAM_FIELD
@@ -323,112 +335,113 @@ public class NameLeafQueryBuilder {
     }
 
 
-    private List<QueryBuilder> getMatchNgramQueryBuilderForPartyAliasesList() {
+    private List<Query.Builder> getMatchNgramQueryBuilderForPartyAliasesList() {
 
         return getMatchNgramQueryBuilderList(PARTY_ALIAS_FIRST_NAME_NGRAM_FIELD,
                 PARTY_ALIAS_LAST_NAME_NGRAM_FIELD
         );
     }
 
-    private List<QueryBuilder> getMustMatchQueryBuilderList(final String firstNameField, final String middleNameField, final String lastNameField) {
+    private List<Query.Builder> getMustMatchQueryBuilderList(final String firstNameField, final String middleNameField, final String lastNameField) {
 
         if (!inSingleNameFieldMode) {
             return getMustMatchQueryBuilderListForSingleField(firstNameField, middleNameField, lastNameField);
         }
 
-        final List<QueryBuilder> queryBuilderList = new ArrayList<>();
+        final List<Query.Builder> queryBuilderList = new ArrayList<>();
 
         if (hasOneName) {
-            queryBuilderList.add(matchQueryBuilder(lastName, firstNameField));
-            queryBuilderList.add(matchQueryBuilder(lastName, lastNameField));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(lastName, firstNameField)));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(lastName, lastNameField)));
         } else if (hasTwoNames) {
-            queryBuilderList.add(matchQueryBuilder(firstName, firstNameField));
-            queryBuilderList.add(matchQueryBuilder(lastName, lastNameField));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(firstName, firstNameField)));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(lastName, lastNameField)));
         } else {
-            queryBuilderList.add(matchQueryBuilder(firstName, firstNameField));
-            queryBuilderList.add(matchQueryBuilder(middleName, middleNameField));
-            queryBuilderList.add(matchQueryBuilder(lastName, lastNameField));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(firstName, firstNameField)));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(middleName, middleNameField)));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(lastName, lastNameField)));
         }
 
         return queryBuilderList;
     }
 
-    private List<QueryBuilder> getMustMatchQueryBuilderListForSingleField(final String firstNameField, final String middleNameField, final String lastNameField) {
+    private List<Query.Builder> getMustMatchQueryBuilderListForSingleField(final String firstNameField, final String middleNameField, final String lastNameField) {
 
-        final List<QueryBuilder> queryBuilderList = new ArrayList<>();
+        final List<Query.Builder> queryBuilderList = new ArrayList<>();
 
         if (!firstName.isEmpty()) {
-            queryBuilderList.add(matchQueryBuilder(firstName, firstNameField));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(firstName, firstNameField)));
         }
 
         if (!middleName.isEmpty()) {
-            queryBuilderList.add(matchQueryBuilder(middleName, middleNameField));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(middleName, middleNameField)));
         }
 
         if (!lastName.isEmpty()) {
-            queryBuilderList.add(matchQueryBuilder(lastName, lastNameField));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(lastName, lastNameField)));
         }
 
         return queryBuilderList;
     }
 
-    private List<QueryBuilder> getMatchNgramQueryBuilderList(final String firstNameField, final String lastNameField) {
+    private List<Query.Builder> getMatchNgramQueryBuilderList(final String firstNameField, final String lastNameField) {
 
         if (!inSingleNameFieldMode) {
             return getMatchNgramQueryBuilderListForMultiFieldSearch(firstNameField, lastNameField);
         }
 
-        final List<QueryBuilder> queryBuilderList = new ArrayList<>();
+        final List<Query.Builder> queryBuilderList = new ArrayList<>();
 
         if (hasOneName) {
-            queryBuilderList.add(matchQueryBuilder(lastName, firstNameField, Optional.of(1.7f)));
-            queryBuilderList.add(matchQueryBuilder(lastName, lastNameField, Optional.of(1.5f)));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(lastName, firstNameField, Optional.of(1.7f))));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(lastName, lastNameField, Optional.of(1.5f))));
         } else {
-            queryBuilderList.add(matchQueryBuilder(firstName, firstNameField, Optional.of(1.7f)));
-            queryBuilderList.add(matchQueryBuilder(lastName, lastNameField, Optional.of(1.5f)));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(firstName, firstNameField, Optional.of(1.7f))));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(lastName, lastNameField, Optional.of(1.5f))));
         }
 
         return queryBuilderList;
     }
 
-    private List<QueryBuilder> getMatchNgramQueryBuilderListForMultiFieldSearch(final String firstNameField, final String lastNameField) {
+    private List<Query.Builder> getMatchNgramQueryBuilderListForMultiFieldSearch(final String firstNameField, final String lastNameField) {
 
-        final List<QueryBuilder> queryBuilderList = new ArrayList<>();
+        final List<Query.Builder> queryBuilderList = new ArrayList<>();
 
         if (!lastName.isEmpty()) {
-            queryBuilderList.add(matchQueryBuilder(lastName, lastNameField, Optional.of(1.7f)));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(lastName, lastNameField, Optional.of(1.7f))));
         }
 
         if (!firstName.isEmpty()) {
-            queryBuilderList.add(matchQueryBuilder(firstName, firstNameField, Optional.of(1.5f)));
+            queryBuilderList.add(convertBuilder(matchQueryBuilder(firstName, firstNameField, Optional.of(1.5f))));
         }
 
         return queryBuilderList;
     }
 
 
-    private MatchQueryBuilder matchQueryBuilder(final String query, final String field) {
+    private MatchQuery.Builder matchQueryBuilder(final String query, final String field) {
         return matchQuery(field, query);
     }
 
-    private MatchQueryBuilder matchQueryBuilder(final String query, final String field, final Optional<Float> boost) {
-        final MatchQueryBuilder builder = matchQuery(field, query);
+    private MatchQuery.Builder matchQueryBuilder(final String query, final String field, final Optional<Float> boost) {
+        final MatchQuery.Builder builder = matchQuery(field, query);
         boost.ifPresent(builder::boost);
         return builder;
     }
 
-    private MultiMatchQueryBuilder crossFieldsMultiMatchQueryBuilder(final String query, final List<String> fields) {
+    private MultiMatchQuery.Builder crossFieldsMultiMatchQueryBuilder(final String query, final List<String> fields) {
 
-        final MultiMatchQueryBuilder builder = multiMatchQuery(query, fields.toArray(new String[0]));
-        builder.type(CROSS_FIELDS);
-
+        final MultiMatchQuery.Builder builder = new MultiMatchQuery.Builder();
+        builder.query(query).fields(fields).type(TextQueryType.CrossFields);
         return builder;
     }
 
-    private QueryBuilder wrapWithAdditionalPartyQueryBuilders(final QueryBuilder queryBuilder) {
-        final BoolQueryBuilder booleanQueryBuilder = boolQuery();
+    private Query.Builder wrapWithAdditionalPartyQueryBuilders(final Query.Builder queryBuilder) {
+        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
         this.additionalPartyQueryBuilders.forEach(booleanQueryBuilder::must);
-        booleanQueryBuilder.must(queryBuilder);
-        return booleanQueryBuilder;
+        booleanQueryBuilder.must(queryBuilder.build());
+        final Query.Builder builder = new Query.Builder();
+        builder.bool(booleanQueryBuilder.build());
+        return builder;
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NameLeafQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NameLeafQueryBuilder.java
@@ -134,8 +134,8 @@ public class NameLeafQueryBuilder {
     public Query.Builder nestedPartiesBuilder() {
 
         final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(false).build());
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(true).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(false, getMustMatchQueryBuilderForPartiesList()).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(true, getMustMatchQueryBuilderForPartiesList()).build());
         if (!allNames.isEmpty()) {
             booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForParties().operator(And).boost(0.4F))).build());
             booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForParties().operator(Or))).build());
@@ -166,8 +166,8 @@ public class NameLeafQueryBuilder {
 
         final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
 
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForPartyAliases(false).build());
-        booleanQueryBuilder.should(getMustMatchQueryBuilderForPartyAliases(true).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(false, getMustMatchQueryBuilderForPartyAliasesList()).build());
+        booleanQueryBuilder.should(getMustMatchQueryBuilderForParties(true, getMustMatchQueryBuilderForPartyAliasesList()).build());
 
         if (!allNames.isEmpty()) {
             booleanQueryBuilder.should(wrapWithAdditionalPartyQueryBuilders(convertBuilder(getMultiMatchQueryBuilderForPartyAliases().operator(And).boost(0.4F))).build());
@@ -196,12 +196,11 @@ public class NameLeafQueryBuilder {
     }
 
 
-    private Query.Builder getMustMatchQueryBuilderForParties(final boolean isFuzziness) {
+    private Query.Builder getMustMatchQueryBuilderForParties(final boolean isFuzziness, final List<Query.Builder> mustMatchQueryBuilderList) {
         final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
 
         this.additionalPartyQueryBuilders.forEach(booleanQueryBuilder::must);
 
-        final List<Query.Builder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartiesList();
         if(isFuzziness){
             mustMatchQueryBuilderList.stream()
                     .map(q -> q.build().match())
@@ -219,32 +218,6 @@ public class NameLeafQueryBuilder {
             mustMatchQueryBuilderList.forEach(b -> booleanQueryBuilder.must(b.build()));
             booleanQueryBuilder.boost(3.0F);
         }
-        return convertBuilder(booleanQueryBuilder);
-    }
-
-    private Query.Builder getMustMatchQueryBuilderForPartyAliases(final boolean isFuzziness) {
-        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
-        this.additionalPartyQueryBuilders.forEach(booleanQueryBuilder::must);
-        final List<Query.Builder> mustMatchQueryBuilderList = getMustMatchQueryBuilderForPartyAliasesList();
-        if(isFuzziness){
-            mustMatchQueryBuilderList.stream()
-                    .map(q -> q.build().match())
-                    .forEach(mqb -> {
-                        MatchQuery.Builder builder = new MatchQuery.Builder();
-                        builder.field(mqb.field());
-                        builder.query(mqb.query());
-                        builder.boost(mqb.boost());
-                        builder.fuzziness(FUZZINESS_AUTO);
-                        booleanQueryBuilder.must(builder.build());
-                    });
-
-
-            booleanQueryBuilder.boost(2.0F);
-        } else {
-            mustMatchQueryBuilderList.forEach(b -> booleanQueryBuilder.must(b.build()));
-            booleanQueryBuilder.boost(3.0F);
-        }
-
         return convertBuilder(booleanQueryBuilder);
     }
 

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NameSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NameSearchQueryBuilder.java
@@ -1,41 +1,41 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.disMaxQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
 import java.util.List;
 
-import org.elasticsearch.index.query.DisMaxQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.DisMaxQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class NameSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... nameQueryParam) {
+    public Query getQueryBuilderBy(final Object... nameQueryParam) {
 
         NameLeafQueryBuilder nameLeafQueryBuilder;
         if (nameQueryParam.length > 2) {
-            nameLeafQueryBuilder = new NameLeafQueryBuilder(valueOf(nameQueryParam[0]), valueOf(nameQueryParam[1]), (List<QueryBuilder>) nameQueryParam[2]);
+            nameLeafQueryBuilder = new NameLeafQueryBuilder(valueOf(nameQueryParam[0]), valueOf(nameQueryParam[1]), (List<Query>) nameQueryParam[2]);
         } else {
-            nameLeafQueryBuilder = new NameLeafQueryBuilder(valueOf(nameQueryParam[0]), (List<QueryBuilder>) nameQueryParam[1]);
+            nameLeafQueryBuilder = new NameLeafQueryBuilder(valueOf(nameQueryParam[0]), (List<Query>) nameQueryParam[1]);
         }
 
         return namesQueryCompositeBuilder(nameLeafQueryBuilder);
     }
 
-    private QueryBuilder namesQueryCompositeBuilder(final NameLeafQueryBuilder nameLeafQueryBuilder) {
-        final DisMaxQueryBuilder disMaxQueryBuilder = disMaxQuery();
+    private Query namesQueryCompositeBuilder(final NameLeafQueryBuilder nameLeafQueryBuilder) {
+        final DisMaxQuery.Builder disMaxQueryBuilder = new DisMaxQuery.Builder();
 
-        disMaxQueryBuilder.add(nameLeafQueryBuilder.nestedPartiesBuilder());
+        disMaxQueryBuilder.queries(nameLeafQueryBuilder.nestedPartiesBuilder().build());
 
-        disMaxQueryBuilder.add(nameLeafQueryBuilder.nestedPartyAliasesBuilder());
+        disMaxQueryBuilder.queries(nameLeafQueryBuilder.nestedPartyAliasesBuilder().build());
 
-        disMaxQueryBuilder.tieBreaker(0.0F);
+        disMaxQueryBuilder.tieBreaker(0.0);
         disMaxQueryBuilder.boost(1.2F);
 
-        return disMaxQueryBuilder;
+        return convertBuilder(disMaxQueryBuilder).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NinoSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NinoSearchQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
+
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.PARTIES_NINO_REFERENCE_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class NinoSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String ninoQueryParam = valueOf(queryParams[0]);
-        return termQuery(PARTIES_NINO_REFERENCE_PATH, ninoQueryParam);
+        return termQuery(PARTIES_NINO_REFERENCE_PATH, ninoQueryParam).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PartyTypeSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PartyTypeSearchQueryBuilder.java
@@ -1,18 +1,18 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.PARTY_TYPE_NESTED_PATH;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termsQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class PartyTypeSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String[] partyTypes = clean(queryParams[0]);
-        return termsQuery(PARTY_TYPE_NESTED_PATH, partyTypes);
+        return termsQuery(PARTY_TYPE_NESTED_PATH, partyTypes).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilder.java
@@ -1,19 +1,19 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.PNC_ID_INDEX;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class PncIdQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String pncId = valueOf(queryParams[0]);
-        return termQuery(PNC_ID_INDEX, pncId);
+        return termQuery(PNC_ID_INDEX, pncId).build();
     }
 }
 

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PostCodeQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PostCodeQueryBuilder.java
@@ -1,18 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.elasticsearch.index.query.Operator.AND;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.matchQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.POSTCODE;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class PostCodeQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
-        return matchQuery(POSTCODE, queryParam[0]).operator(AND);
+    public Query getQueryBuilderBy(final Object... queryParam) {
+        final Query.Builder builder = new Query.Builder();
+        builder.match(matchQuery(POSTCODE, String.valueOf(queryParam[0]) ).operator(Operator.And).build());
+        return builder.build();
     }
 }
 

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ProceedingsConcludedQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ProceedingsConcludedQueryBuilder.java
@@ -1,33 +1,36 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.PROCEEDINGS_CONCLUDED_INDEX;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class ProceedingsConcludedQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
-        final String proceedingsConcluded = valueOf(queryParams[0]);
-        final BoolQueryBuilder booleanQueryBuilder = boolQuery();
+    public Query getQueryBuilderBy(final Object... queryParams) {
+        final Boolean proceedingsConcluded = (Boolean)queryParams[0];
+        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
 
-        if ("false".equalsIgnoreCase(proceedingsConcluded)) {
-            booleanQueryBuilder.should(termQuery(PROCEEDINGS_CONCLUDED_INDEX, proceedingsConcluded));
-            booleanQueryBuilder.should(mustNot());
-            return booleanQueryBuilder;
+        if (!proceedingsConcluded) {
+            booleanQueryBuilder.should(termQuery(PROCEEDINGS_CONCLUDED_INDEX, proceedingsConcluded).build());
+            booleanQueryBuilder.should(mustNot().build());
+            return convertBuilder(booleanQueryBuilder).build();
         }
-        return boolQuery().must(termQuery(PROCEEDINGS_CONCLUDED_INDEX, proceedingsConcluded));
+        return convertBuilder(booleanQueryBuilder.must(termQuery(PROCEEDINGS_CONCLUDED_INDEX, proceedingsConcluded).build())).build();
     }
 
-    private QueryBuilder mustNot() {
-        final BoolQueryBuilder booleanQueryBuilder2 = boolQuery();
-        return  booleanQueryBuilder2.mustNot(existsQuery(PROCEEDINGS_CONCLUDED_INDEX));
+    private Query.Builder mustNot() {
+        final BoolQuery.Builder booleanQueryBuilder = new BoolQuery.Builder();
+        booleanQueryBuilder.mustNot(m -> m.exists(e -> e.field(PROCEEDINGS_CONCLUDED_INDEX)));
+        return convertBuilder(booleanQueryBuilder);
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ProsecutingAuthoritySearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ProsecutingAuthoritySearchQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.PROSECUTING_AUTHORITY;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class ProsecutingAuthoritySearchQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
-        return boolQuery()
-                .filter(new TermQueryBuilder(PROSECUTING_AUTHORITY, valueOf(queryParam[0])));
+    public Query getQueryBuilderBy(final Object... queryParam) {
+        return convertBuilder((new BoolQuery.Builder())
+                .filter(termQuery(PROSECUTING_AUTHORITY, valueOf(queryParam[0])).build())).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/VirtualBoxHearingQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/VirtualBoxHearingQueryBuilder.java
@@ -2,18 +2,19 @@ package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_VIRTUAL_BOX_HEARING_PATH;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class VirtualBoxHearingQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final boolean isBoxWork = parseBoolean(valueOf(queryParams[0]));
-        return termQuery(IS_VIRTUAL_BOX_HEARING_PATH, isBoxWork);
+        return termQuery(IS_VIRTUAL_BOX_HEARING_PATH, isBoxWork).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CaseStatusQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CaseStatusQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.CASE_STATUS;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class CaseStatusQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
-        return boolQuery()
-                .filter(new TermQueryBuilder(CASE_STATUS, valueOf(queryParam[0])));
+    public Query getQueryBuilderBy(final Object... queryParam) {
+        return convertBuilder((new BoolQuery.Builder())
+                .filter(termQuery(CASE_STATUS, valueOf(queryParam[0])).build())).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CaseTypeQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CaseTypeQueryBuilder.java
@@ -1,19 +1,18 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
-import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.CASE_TYPE;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class CaseTypeQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
-        return boolQuery()
-                .filter(new TermQueryBuilder(CASE_TYPE, valueOf(queryParam[0])));
+    public Query getQueryBuilderBy(final Object... queryParam) {
+        final Query.Builder builder = new Query.Builder();
+        builder.bool(b -> b.filter(termQuery(CASE_TYPE, String.valueOf(queryParam[0])).build()));
+        return builder.build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CjsAreaQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CjsAreaQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.CJS_AREA;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class CjsAreaQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
-        return boolQuery()
-                .filter(new TermQueryBuilder(CJS_AREA, valueOf(queryParam[0])));
+    public Query getQueryBuilderBy(final Object... queryParam) {
+        return convertBuilder((new BoolQuery.Builder())
+                .filter(termQuery(CJS_AREA, valueOf(queryParam[0])).build())).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CourtHouseQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CourtHouseQueryBuilder.java
@@ -1,17 +1,17 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.COURT_HOUSE_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class CourtHouseQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
-        return termQuery(COURT_HOUSE_PATH, valueOf(queryParams[0]));
+    public Query getQueryBuilderBy(final Object... queryParams) {
+        return termQuery(COURT_HOUSE_PATH, valueOf(queryParams[0])).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CourtRoomQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CourtRoomQueryBuilder.java
@@ -1,17 +1,18 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.COURT_ROOM_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class CourtRoomQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
-        return termQuery(COURT_ROOM_PATH, valueOf(queryParams[0]));
+    public Query getQueryBuilderBy(final Object... queryParams) {
+        return termQuery(COURT_ROOM_PATH, valueOf(queryParams[0])).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CpsAreaQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CpsAreaQueryBuilder.java
@@ -1,19 +1,19 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.CPS_AREA;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class CpsAreaQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
-        return boolQuery()
-                .filter(new TermQueryBuilder(CPS_AREA, valueOf(queryParam[0])));
+    public Query getQueryBuilderBy(final Object... queryParam) {
+        final Query.Builder builder= new Query.Builder();
+        builder.bool(b -> b.filter(termQuery(CPS_AREA, valueOf(queryParam[0])).build()));
+        return builder.build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CpsUnitQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CpsUnitQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.CPS_UNIT;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class CpsUnitQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
-        return boolQuery()
-                .filter(new TermQueryBuilder(CPS_UNIT, valueOf(queryParam[0])));
+    public Query getQueryBuilderBy(final Object... queryParam) {
+        return convertBuilder((new BoolQuery.Builder())
+                .filter(termQuery(CPS_UNIT, valueOf(queryParam[0])).build())).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CrownAdvocateQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CrownAdvocateQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.CROWN_ADVOCATE;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class CrownAdvocateQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
-        return boolQuery()
-                .filter(new TermQueryBuilder(CROWN_ADVOCATE, valueOf(queryParam[0])));
+    public Query getQueryBuilderBy(final Object... queryParam) {
+        return convertBuilder((new BoolQuery.Builder())
+                .filter(termQuery(CROWN_ADVOCATE, valueOf(queryParam[0])).build())).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/ExcludeAutomaticallyLinkedCasesQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/ExcludeAutomaticallyLinkedCasesQueryBuilder.java
@@ -1,29 +1,31 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.apache.lucene.search.join.ScoreMode.Avg;
-import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.nestedQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.LINKED_CASES_ID_PATH;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.LINKED_CASES_NESTED_PATH;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.MANUALLY_LINKED_CASES_PATH;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+
 
 public class ExcludeAutomaticallyLinkedCasesQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
 
-        final BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+        final BoolQuery.Builder boolQueryBuilder = new BoolQuery.Builder();
 
-        final BoolQueryBuilder subQuery = QueryBuilders.boolQuery();
-        subQuery.must(nestedQuery(LINKED_CASES_NESTED_PATH,QueryBuilders.termQuery(MANUALLY_LINKED_CASES_PATH,"false"),Avg));
-        subQuery.must(nestedQuery(LINKED_CASES_NESTED_PATH,QueryBuilders.termQuery(LINKED_CASES_ID_PATH,valueOf(queryParams[0])),Avg));
-        return boolQueryBuilder.mustNot(subQuery);
+        final BoolQuery.Builder subQuery = new BoolQuery.Builder();
+        subQuery.must(nestedQuery(LINKED_CASES_NESTED_PATH,termQuery(MANUALLY_LINKED_CASES_PATH,"false")).build());
+        subQuery.must(nestedQuery(LINKED_CASES_NESTED_PATH,termQuery(LINKED_CASES_ID_PATH,valueOf(queryParams[0]))).build());
+        return convertBuilder(boolQueryBuilder.mustNot(subQuery.build())).build();
 
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/HearingDateTimeQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/HearingDateTimeQueryBuilder.java
@@ -1,41 +1,42 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.builders.utils.HearingDateUtil.stringToDate;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.HEARING_DATE_TIME_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.RangeQueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.json.JsonData;
 
 public class HearingDateTimeQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String hearingDateFromQueryParam = valueOf(queryParams[0]);
         final String hearingDateToQueryParam = valueOf(queryParams[1]);
 
         if (!hearingDateFromQueryParam.isEmpty() && hearingDateToQueryParam.isEmpty()) {
-            return getTermBuilderQuery(hearingDateFromQueryParam);
+            return termQuery(HEARING_DATE_TIME_PATH, hearingDateFromQueryParam).build();
 
         }
 
         if (!hearingDateToQueryParam.isEmpty() && hearingDateFromQueryParam.isEmpty()) {
-            return getTermBuilderQuery(hearingDateToQueryParam);
+            return termQuery(HEARING_DATE_TIME_PATH, hearingDateToQueryParam).build();
         }
 
-        return getRangeBuilderQuery(hearingDateFromQueryParam, hearingDateToQueryParam);
+        return getRangeBuilderQuery(hearingDateFromQueryParam, hearingDateToQueryParam).build();
     }
 
-    private RangeQueryBuilder getRangeBuilderQuery(final String hearingDateFromQueryParam, final String hearingDateToQueryParam) {
-        return rangeQuery(HEARING_DATE_TIME_PATH).from(stringToDate(hearingDateFromQueryParam)).to(stringToDate(hearingDateToQueryParam));
-    }
-
-    private TermQueryBuilder getTermBuilderQuery(final String queryParam) {
-        return termQuery(HEARING_DATE_TIME_PATH, queryParam);
+    private Query.Builder getRangeBuilderQuery(final String hearingDateFromQueryParam, final String hearingDateToQueryParam) {
+        final Query.Builder builder = new Query.Builder();
+        builder.range(r -> r
+                .untyped(u -> u
+                        .field(HEARING_DATE_TIME_PATH)
+                        .gte(JsonData.of(stringToDate(hearingDateFromQueryParam)))
+                        .lte(JsonData.of(stringToDate(hearingDateToQueryParam)))
+                ));
+        return builder;
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/HearingTypeSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/HearingTypeSearchQueryBuilder.java
@@ -1,17 +1,18 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.HEARING_TYPE_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class HearingTypeSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
-        return termQuery(HEARING_TYPE_PATH, valueOf(queryParams[0]));
+    public Query getQueryBuilderBy(final Object... queryParams) {
+        return termQuery(HEARING_TYPE_PATH, valueOf(queryParams[0])).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/JurisdictionQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/JurisdictionQueryBuilder.java
@@ -1,17 +1,17 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
-import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.JURISDICTION_PATH;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termsQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class JurisdictionQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
+    public Query getQueryBuilderBy(final Object... queryParams) {
         final String[] jurisdiction = clean(queryParams[0]);
-        return termsQuery(JURISDICTION_PATH, jurisdiction);
+        return termsQuery(JURISDICTION_PATH, jurisdiction).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/OffenceCodeSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/OffenceCodeSearchQueryBuilder.java
@@ -1,18 +1,19 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.*;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.PARTIES_OFFENCE_CODE_PATH;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class OffenceCodeSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
-        return termQuery(PARTIES_OFFENCE_CODE_PATH, valueOf(queryParams[0]));
+    public Query getQueryBuilderBy(final Object... queryParams) {
+        return termQuery(PARTIES_OFFENCE_CODE_PATH, valueOf(queryParams[0])).build();
     }
 }
 

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/OicShoulderNumberQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/OicShoulderNumberQueryBuilder.java
@@ -1,17 +1,18 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.PARTIES_OIC_SHOULDER_NUMBER_PATH;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class OicShoulderNumberQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
-        return termQuery(PARTIES_OIC_SHOULDER_NUMBER_PATH, valueOf(queryParams[0]));
+    public Query getQueryBuilderBy(final Object... queryParams) {
+        return termQuery(PARTIES_OIC_SHOULDER_NUMBER_PATH, valueOf(queryParams[0])).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/OperationNameQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/OperationNameQueryBuilder.java
@@ -1,22 +1,23 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.matchQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.OPERATION_NAME;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.OPERATION_NAME_PATH_NGRAMMED;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class OperationNameQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
+    public Query getQueryBuilderBy(final Object... queryParam) {
 
-        return boolQuery()
-                .should(matchQuery(OPERATION_NAME, valueOf(queryParam[0])))
-                .should(matchQuery(OPERATION_NAME_PATH_NGRAMMED, valueOf(queryParam[0])));
+        return convertBuilder((new BoolQuery.Builder())
+                .should(matchQuery(OPERATION_NAME, valueOf(queryParam[0])).build())
+                .should(matchQuery(OPERATION_NAME_PATH_NGRAMMED, valueOf(queryParam[0])).build())).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/ParalegalOfficerQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/ParalegalOfficerQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.PARALEGAL_OFFICER;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class ParalegalOfficerQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
-        return boolQuery()
-                .filter(new TermQueryBuilder(PARALEGAL_OFFICER, valueOf(queryParam[0])));
+    public Query getQueryBuilderBy(final Object... queryParam) {
+        return convertBuilder ((new BoolQuery.Builder())
+                .filter(termQuery(PARALEGAL_OFFICER, valueOf(queryParam[0])).build())).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/ProsecutorSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/ProsecutorSearchQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.PROSECUTOR;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class ProsecutorSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
-        return boolQuery()
-                .filter(new TermQueryBuilder(PROSECUTOR, valueOf(queryParam[0])));
+    public Query getQueryBuilderBy(final Object... queryParam) {
+        return convertBuilder((new BoolQuery.Builder())
+                .filter(termQuery(PROSECUTOR, valueOf(queryParam[0])).build())).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/UrnSearchQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/UrnSearchQueryBuilder.java
@@ -1,19 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.termQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.URN;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class UrnSearchQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParam) {
-        return boolQuery()
-                .filter(new TermQueryBuilder(URN, valueOf(queryParam[0])));
+    public Query getQueryBuilderBy(final Object... queryParam) {
+        return convertBuilder((new BoolQuery.Builder())
+                .filter(termQuery(URN, valueOf(queryParam[0])).build())).build();
     }
 }

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/WitnessCareUnitQueryBuilder.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/WitnessCareUnitQueryBuilder.java
@@ -1,18 +1,19 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static java.lang.String.valueOf;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.matchQuery;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.WITNESS_CARE_UNIT;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class WitnessCareUnitQueryBuilder implements ElasticSearchQueryBuilder {
 
     @Override
-    public QueryBuilder getQueryBuilderBy(final Object... queryParams) {
-        return matchQuery(WITNESS_CARE_UNIT, valueOf(queryParams[0]));
+    public Query getQueryBuilderBy(final Object... queryParams) {
+        return convertBuilder(matchQuery(WITNESS_CARE_UNIT, valueOf(queryParams[0]))).build();
     }
 }
 

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/AbstractQueryBuilderService.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/AbstractQueryBuilderService.java
@@ -1,9 +1,8 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.service;
 
 import static java.util.stream.Collectors.toList;
-import static org.apache.lucene.search.join.ScoreMode.Avg;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.convertBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder.nestedQuery;
 
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilderCache;
@@ -13,9 +12,9 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.InnerHitBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.search.InnerHits;
 
 public abstract class AbstractQueryBuilderService {
 
@@ -23,43 +22,43 @@ public abstract class AbstractQueryBuilderService {
     protected ElasticSearchQueryBuilderCache elasticSearchQueryBuilderCache;
 
     protected void addFilterToQueryIfPresent(final String param, final String queryBuilderCacheKey,
-                                           final BoolQueryBuilder queryBuilder) {
+                                           final BoolQuery.Builder queryBuilder) {
         if (!param.isEmpty()) {
             queryBuilder.filter(getQueryBuilder(queryBuilderCacheKey, param));
         }
     }
 
-    protected QueryBuilder getQueryBuilder(final String queryBuilderCacheKey,
+    protected Query getQueryBuilder(final String queryBuilderCacheKey,
                                          final Object... params) {
         final ElasticSearchQueryBuilder unifiedSearchQueryBuilderBy = elasticSearchQueryBuilderCache
                 .getQueryBuilderFromCacheBy(queryBuilderCacheKey);
         return unifiedSearchQueryBuilderBy.getQueryBuilderBy(params);
     }
 
-    protected QueryBuilder createAdditionalMustFilterWithInnerHits(final String nestedPath,
-                                                                 final List<QueryBuilder> allInnerQueries) {
+    protected Query createAdditionalMustFilterWithInnerHits(final String nestedPath,
+                                                                 final List<Query> allInnerQueries) {
         if (allInnerQueries.isEmpty()) {
             return null;
         }
 
-        final BoolQueryBuilder innerBooleanQueryBuilder = boolQuery();
+        final BoolQuery.Builder innerBooleanQueryBuilder = new BoolQuery.Builder();
         allInnerQueries.forEach(innerBooleanQueryBuilder::must);
-        return nestedQuery(nestedPath, innerBooleanQueryBuilder, Avg)
-                .innerHit(new InnerHitBuilder("parties"));
+        return convertBuilder(nestedQuery(nestedPath, convertBuilder(innerBooleanQueryBuilder))
+                .innerHits(InnerHits.of(i -> i.name("parties")))).build();
     }
 
-    protected QueryBuilder createAdditionalMustFilter(final String nestedPath,
-                                                    final List<QueryBuilder> allInnerQueries) {
+    protected Query createAdditionalMustFilter(final String nestedPath,
+                                                    final List<Query> allInnerQueries) {
         if (allInnerQueries.isEmpty()) {
             return null;
         }
 
-        final BoolQueryBuilder innerBooleanQueryBuilder = boolQuery();
+        final BoolQuery.Builder innerBooleanQueryBuilder = new BoolQuery.Builder();
         allInnerQueries.forEach(innerBooleanQueryBuilder::must);
-        return nestedQuery(nestedPath, innerBooleanQueryBuilder, Avg);
+        return convertBuilder(nestedQuery(nestedPath, convertBuilder(innerBooleanQueryBuilder))).build();
     }
 
-    protected List<QueryBuilder> createFilters(final Map<String, Object> parameterAndValues) {
+    protected List<Query> createFilters(final Map<String, Object> parameterAndValues) {
         return parameterAndValues.entrySet().stream().
                 filter(entry -> !hasNoValue(entry.getValue())).
                 map(entry -> getQueryBuilder(entry.getKey(), entry.getValue())).
@@ -67,15 +66,15 @@ public abstract class AbstractQueryBuilderService {
     }
 
 
-    protected void addMustToQuery(final String queryBuilderCacheKey, final BoolQueryBuilder queryBuilder, final Object... params) {
+    protected void addMustToQuery(final String queryBuilderCacheKey, final BoolQuery.Builder queryBuilder, final Object... params) {
         queryBuilder.must(getQueryBuilder(queryBuilderCacheKey, params));
     }
 
-    protected void addMustNotToQuery(final String queryBuilderCacheKey, final BoolQueryBuilder queryBuilder, final Object... params) {
+    protected void addMustNotToQuery(final String queryBuilderCacheKey, final BoolQuery.Builder queryBuilder, final Object... params) {
         queryBuilder.mustNot(getQueryBuilder(queryBuilderCacheKey, params));
     }
 
-    protected void addFilterToQuery(final String queryBuilderCacheKey, final BoolQueryBuilder queryBuilder, final Object... params) {
+    protected void addFilterToQuery(final String queryBuilderCacheKey, final BoolQuery.Builder queryBuilder, final Object... params) {
         queryBuilder.filter(getQueryBuilder(queryBuilderCacheKey, params));
     }
 

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/AbstractQueryBuilderService.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/AbstractQueryBuilderService.java
@@ -10,7 +10,7 @@ import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQu
 import java.util.List;
 import java.util.Map;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/CaseQueryBuilderService.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/CaseQueryBuilderService.java
@@ -57,7 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/CpsCaseQueryBuilderService.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/CpsCaseQueryBuilderService.java
@@ -40,7 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import com.google.common.collect.ImmutableMap;

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/utils/EnumValidator.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/utils/EnumValidator.java
@@ -7,7 +7,8 @@ public class EnumValidator {
 
     public static  <T extends Enum<T>> boolean isValidEnum(Class<T> enumType, String key){
         try {
-            Enum.valueOf(enumType, trimToEmpty(key).toUpperCase());
+            final String value = trimToEmpty(key);
+            Enum.valueOf(enumType, value.substring(0,1).toUpperCase() + value.substring(1).toLowerCase());
             return true;
         } catch(IllegalArgumentException e) {
             return false;

--- a/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/utils/QueryBuilderUtils.java
+++ b/unifiedsearchquery-builders/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/builders/utils/QueryBuilderUtils.java
@@ -1,0 +1,16 @@
+package uk.gov.moj.cpp.unifiedsearch.query.builders.utils;
+
+
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+
+public class QueryBuilderUtils {
+    public static MatchQuery.Builder copyQuery(MatchQuery query){
+        MatchQuery.Builder mqBuilder = new MatchQuery.Builder()
+                .field(query.field())
+                .query(query.query());
+        if (query.boost() != null) mqBuilder.boost(query.boost());
+        if (query.operator() != null) mqBuilder.operator(query.operator());
+        if (query.fuzziness() != null) mqBuilder.fuzziness(query.fuzziness());
+        return mqBuilder;
+    }
+}

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/UnifiedSearchQueryBuilderProducerTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/UnifiedSearchQueryBuilderProducerTest.java
@@ -13,8 +13,8 @@ import uk.gov.justice.services.unifiedsearch.UnifiedSearchName;
 import uk.gov.moj.cpp.unifiedsearch.query.builders.service.CaseQueryBuilderService;
 import uk.gov.moj.cpp.unifiedsearch.query.builders.service.CpsCaseQueryBuilderService;
 
-import javax.enterprise.inject.InjectionException;
-import javax.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.InjectionException;
+import jakarta.enterprise.inject.spi.InjectionPoint;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/AddressQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/AddressQueryBuilderTest.java
@@ -4,9 +4,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.junit.jupiter.api.Test;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class AddressQueryBuilderTest {
 
@@ -17,13 +18,12 @@ public class AddressQueryBuilderTest {
 
         final String address = "156 Long street Liverpool";
 
-        final QueryBuilder actualQueryBuilder = addressQueryBuilder.getQueryBuilderBy(address);
+        final Query actualQuery = addressQueryBuilder.getQueryBuilderBy(address);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        final MatchQueryBuilder matchQueryBuilder = (MatchQueryBuilder) actualQueryBuilder;
-        assertThat(matchQueryBuilder.getName(), is("match"));
-        assertThat(matchQueryBuilder.fieldName(), is("parties.addressLines"));
-        assertThat(matchQueryBuilder.value(), is(address));
+        assertThat(actualQuery, is(notNullValue()));
+        final MatchQuery matchQueryBuilder = actualQuery.match();
+        assertThat(matchQueryBuilder.field(), is("parties.addressLines"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(address));
     }
 
 

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ApplicationTypeQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ApplicationTypeQueryBuilderTest.java
@@ -1,13 +1,12 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.APPLICATION_TYPE_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.Test;
 
 public class ApplicationTypeQueryBuilderTest {
@@ -19,16 +18,15 @@ public class ApplicationTypeQueryBuilderTest {
     public void shouldCreateQueryBuilder() {
 
         final String applicationTypeToFilterBy = "Application to test the class";
-        final QueryBuilder queryBuilder = applicationTypeQueryBuilder.getQueryBuilderBy(applicationTypeToFilterBy);
+        final Query query = applicationTypeQueryBuilder.getQueryBuilderBy(applicationTypeToFilterBy);
 
-        assertThat(queryBuilder, is(notNullValue()));
+        assertThat(query, is(notNullValue()));
+        final TermQuery termQueryBuilder = query.term();
+        assertThat(termQueryBuilder, notNullValue());
 
-        assertThat(queryBuilder, instanceOf(TermQueryBuilder.class));
 
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) queryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(APPLICATION_TYPE_PATH));
-        assertThat(termQueryBuilder.value(), is(applicationTypeToFilterBy));
+        assertThat(termQueryBuilder.field(), is(APPLICATION_TYPE_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(applicationTypeToFilterBy));
 
     }
 

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ArrestSummonsNumberSearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ArrestSummonsNumberSearchQueryBuilderTest.java
@@ -1,13 +1,12 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.PARTIES_ASN_REFERENCE_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,15 +23,13 @@ public class ArrestSummonsNumberSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForHearingDateFrom() {
         final String asn = "12345678ABCD";
 
-        final QueryBuilder actualQueryBuilder = arrestSummonsNumberSearchQueryBuilder.getQueryBuilderBy(asn);
+        final Query actualQuery = arrestSummonsNumberSearchQueryBuilder.getQueryBuilderBy(asn);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
+        assertThat(actualQuery, is(notNullValue()));
+        final TermQuery termQueryBuilder = actualQuery.term();
+        assertThat(termQueryBuilder, notNullValue());
 
-        assertThat(actualQueryBuilder, instanceOf(TermQueryBuilder.class));
-
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) actualQueryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(PARTIES_ASN_REFERENCE_PATH));
-        assertThat(termQueryBuilder.value(), is(asn));
+        assertThat(termQueryBuilder.field(), is(PARTIES_ASN_REFERENCE_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(asn));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/BoxHearingQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/BoxHearingQueryBuilderTest.java
@@ -1,13 +1,12 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_BOX_HEARING_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.Test;
 
 public class BoxHearingQueryBuilderTest {
@@ -19,16 +18,14 @@ public class BoxHearingQueryBuilderTest {
     public void shouldCreateQueryBuilder() {
 
         final String isBoxHearing = "true";
-        final QueryBuilder queryBuilder = boxHearingQueryBuilder.getQueryBuilderBy(isBoxHearing);
+        final Query query = boxHearingQueryBuilder.getQueryBuilderBy(isBoxHearing);
 
-        assertThat(queryBuilder, is(notNullValue()));
+        assertThat(query, is(notNullValue()));
+        final TermQuery termQueryBuilder = query.term();
+        assertThat(termQueryBuilder, notNullValue());
 
-        assertThat(queryBuilder, instanceOf(TermQueryBuilder.class));
-
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) queryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(IS_BOX_HEARING_PATH));
-        assertThat(termQueryBuilder.value(), is(true));
+        assertThat(termQueryBuilder.field(), is(IS_BOX_HEARING_PATH));
+        assertThat(termQueryBuilder.value().booleanValue(), is(true));
     }
 
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CaseStatusQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CaseStatusQueryBuilderTest.java
@@ -9,12 +9,13 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.jupiter.api.Assertions.*;
-
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.ActiveCaseStatusEnum.getActiveCaseStatusEnumValues;
+
 import java.util.List;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermsQueryBuilder;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,19 +32,17 @@ public class CaseStatusQueryBuilderTest {
     @Test
     public void shouldGetQueryBuilderBy() {
 
-        final QueryBuilder actualQueryBuilder = caseStatusQueryBuilder.getQueryBuilderBy(" ACTIVE  , INACTIVE  ");
+        final Query actualQuery = caseStatusQueryBuilder.getQueryBuilderBy(" ACTIVE  , INACTIVE  ");
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
+        assertThat(actualQuery, is(notNullValue()));
 
-        assertThat(actualQueryBuilder, instanceOf(TermsQueryBuilder.class));
+        final TermsQuery actualTermsQuery = actualQuery.terms();
 
-        final TermsQueryBuilder actualTermsQuery = (TermsQueryBuilder) actualQueryBuilder;
-
-        assertThat(actualTermsQuery.fieldName(), is("caseStatus"));
-        final List<Object> queryValues = actualTermsQuery.values();
+        assertThat(actualTermsQuery.field(), is("caseStatus"));
+        final List<FieldValue> queryValues = actualTermsQuery.terms().value();
 
         assertThat(queryValues, hasSize(2));
-        assertThat(queryValues, hasItems("ACTIVE","INACTIVE"));
+        assertThat(queryValues.stream().map(FieldValue::stringValue).toList(), hasItems("ACTIVE","INACTIVE"));
     }
 
     @Test

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CourtSearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CourtSearchQueryBuilderTest.java
@@ -1,13 +1,12 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.HEARING_DAY_COURTCENTRE_REFERENCE_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,14 +23,14 @@ public class CourtSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForCourtQueryBuilder() {
         final String courtId = "3fdcf368-ea16-40cd-a7f2-d25b04637721";
 
-        final QueryBuilder actualQueryBuilder = courtSearchQueryBuilder.getQueryBuilderBy(courtId);
+        final Query actualQuery = courtSearchQueryBuilder.getQueryBuilderBy(courtId);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf((TermQueryBuilder.class)));
+        assertThat(actualQuery, is(notNullValue()));
+        final TermQuery termQueryBuilder = actualQuery.term();
+        assertThat(termQueryBuilder, notNullValue());
 
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) actualQueryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(HEARING_DAY_COURTCENTRE_REFERENCE_PATH));
-        assertThat(termQueryBuilder.value(), is(courtId));
+
+        assertThat(termQueryBuilder.field(), is(HEARING_DAY_COURTCENTRE_REFERENCE_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(courtId));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CroNumberQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CroNumberQueryBuilderTest.java
@@ -6,8 +6,8 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.CRO_NUMBER_INDEX;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.Test;
 
 public class CroNumberQueryBuilderTest {
@@ -19,15 +19,13 @@ public class CroNumberQueryBuilderTest {
     public void shouldCreateExactMatchQueryBuilderForCroNumberNumber() {
 
         final String croNumber = "croNumber";
-        final QueryBuilder queryBuilder = croNumberSearchQueryBuilder.getQueryBuilderBy(croNumber);
+        final Query query = croNumberSearchQueryBuilder.getQueryBuilderBy(croNumber);
 
-        assertThat(queryBuilder, is(notNullValue()));
+        assertThat(query, is(notNullValue()));
+        final TermQuery termQueryBuilder = query.term();
+        assertThat(termQueryBuilder, notNullValue());
 
-        assertThat(queryBuilder, instanceOf(TermQueryBuilder.class));
-
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) queryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(CRO_NUMBER_INDEX));
-        assertThat(termQueryBuilder.value(), is(croNumber));
+        assertThat(termQueryBuilder.field(), is(CRO_NUMBER_INDEX));
+        assertThat(termQueryBuilder.value().stringValue(), is(croNumber));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CrownOrMagistratesQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/CrownOrMagistratesQueryBuilderTest.java
@@ -8,9 +8,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_CROWN_COURT;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_MAGISTRATE_COURT;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.Test;
 
 public class CrownOrMagistratesQueryBuilderTest {
@@ -20,31 +20,29 @@ public class CrownOrMagistratesQueryBuilderTest {
         final CrownOrMagistratesQueryBuilder crownOrMagistratesQueryBuilder = new CrownOrMagistratesQueryBuilder();
 
         final String crownOrMagistratesParam = "true";
-        final QueryBuilder queryBuilder = crownOrMagistratesQueryBuilder.getQueryBuilderBy(crownOrMagistratesParam);
+        final Query query = crownOrMagistratesQueryBuilder.getQueryBuilderBy(crownOrMagistratesParam);
 
-        assertThat(queryBuilder, is(notNullValue()));
-        assertThat(queryBuilder, instanceOf((BoolQueryBuilder.class)));
+        assertThat(query, is(notNullValue()));
+        final BoolQuery actualBoolQueryBuilder = query.bool();
+        assertThat(actualBoolQueryBuilder, instanceOf((BoolQuery.class)));
 
-        final BoolQueryBuilder actualBoolQueryBuilder = (BoolQueryBuilder) queryBuilder;
-        assertThat(actualBoolQueryBuilder.getName(), is("bool"));
+
         assertThat(actualBoolQueryBuilder.must(), hasSize(0));
         assertThat(actualBoolQueryBuilder.should(), hasSize(2));
 
-        final QueryBuilder firstShouldClause = actualBoolQueryBuilder.should().get(0);
-        final QueryBuilder secondShouldClause = actualBoolQueryBuilder.should().get(1);
+        final Query firstShouldClause = actualBoolQueryBuilder.should().get(0);
+        final Query secondShouldClause = actualBoolQueryBuilder.should().get(1);
 
-        assertThat(firstShouldClause, instanceOf(TermQueryBuilder.class));
-        assertThat(secondShouldClause, instanceOf(TermQueryBuilder.class));
+        assertThat(firstShouldClause.term(), instanceOf(TermQuery.class));
+        assertThat(secondShouldClause.term(), instanceOf(TermQuery.class));
 
-        final TermQueryBuilder firstTerm = (TermQueryBuilder) firstShouldClause;
-        assertThat(firstTerm.getName(), is("term"));
-        assertThat(firstTerm.fieldName(), is(IS_CROWN_COURT));
-        assertThat(firstTerm.value(), is(true));
+        final TermQuery firstTerm = firstShouldClause.term();
+        assertThat(firstTerm.field(), is(IS_CROWN_COURT));
+        assertThat(firstTerm.value().booleanValue(), is(true));
 
-        final TermQueryBuilder secondTerm = (TermQueryBuilder) secondShouldClause;
-        assertThat(secondTerm.getName(), is("term"));
-        assertThat(secondTerm.fieldName(), is(IS_MAGISTRATE_COURT));
-        assertThat(secondTerm.value(), is(true));
+        final TermQuery secondTerm = secondShouldClause.term();
+        assertThat(secondTerm.field(), is(IS_MAGISTRATE_COURT));
+        assertThat(secondTerm.value().booleanValue(), is(true));
     }
 
     @Test
@@ -52,30 +50,26 @@ public class CrownOrMagistratesQueryBuilderTest {
         final CrownOrMagistratesQueryBuilder crownOrMagistratesQueryBuilder = new CrownOrMagistratesQueryBuilder();
 
         final String crownOrMagistratesParam = "false";
-        final QueryBuilder queryBuilder = crownOrMagistratesQueryBuilder.getQueryBuilderBy(crownOrMagistratesParam);
-        assertThat(queryBuilder, is(notNullValue()));
-        assertThat(queryBuilder, instanceOf((BoolQueryBuilder.class)));
+        final Query query = crownOrMagistratesQueryBuilder.getQueryBuilderBy(crownOrMagistratesParam);
+        assertThat(query, is(notNullValue()));
 
-        final BoolQueryBuilder actualBoolQueryBuilder = (BoolQueryBuilder) queryBuilder;
-        assertThat(actualBoolQueryBuilder.getName(), is("bool"));
+        final BoolQuery actualBoolQueryBuilder = query.bool();
         assertThat(actualBoolQueryBuilder.must(), hasSize(2));
         assertThat(actualBoolQueryBuilder.should(), hasSize(0));
 
-        final QueryBuilder firstMustClause = actualBoolQueryBuilder.must().get(0);
-        final QueryBuilder secondShouldClause = actualBoolQueryBuilder.must().get(1);
+        final Query firstMustClause = actualBoolQueryBuilder.must().get(0);
+        final Query secondShouldClause = actualBoolQueryBuilder.must().get(1);
 
-        assertThat(firstMustClause, instanceOf(TermQueryBuilder.class));
-        assertThat(secondShouldClause, instanceOf(TermQueryBuilder.class));
+        assertThat(firstMustClause.term(), instanceOf(TermQuery.class));
+        assertThat(secondShouldClause.term(), instanceOf(TermQuery.class));
 
-        final TermQueryBuilder firstTerm = (TermQueryBuilder) firstMustClause;
-        assertThat(firstTerm.getName(), is("term"));
-        assertThat(firstTerm.fieldName(), is(IS_CROWN_COURT));
-        assertThat(firstTerm.value(), is(false));
+        final TermQuery firstTerm = firstMustClause.term();
+        assertThat(firstTerm.field(), is(IS_CROWN_COURT));
+        assertThat(firstTerm.value().booleanValue(), is(false));
 
-        final TermQueryBuilder secondTerm = (TermQueryBuilder) secondShouldClause;
-        assertThat(secondTerm.getName(), is("term"));
-        assertThat(secondTerm.fieldName(), is(IS_MAGISTRATE_COURT));
-        assertThat(secondTerm.value(), is(false));
+        final TermQuery secondTerm = secondShouldClause.term();
+        assertThat(secondTerm.field(), is(IS_MAGISTRATE_COURT));
+        assertThat(secondTerm.value().booleanValue(), is(false));
     }
 
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/DateOfBirthSearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/DateOfBirthSearchQueryBuilderTest.java
@@ -1,13 +1,12 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.PARTIES_DATE_OF_BIRTH_REFERENCE_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,15 +23,13 @@ public class DateOfBirthSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForHearingDateFrom() {
         final String dateOfBirth = "1954-04-29";
 
-        final QueryBuilder actualQueryBuilder = dateOfBirthSearchQueryBuilder.getQueryBuilderBy(dateOfBirth);
+        final Query actualQuery = dateOfBirthSearchQueryBuilder.getQueryBuilderBy(dateOfBirth);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
+        assertThat(actualQuery, is(notNullValue()));
+        final TermQuery termQueryBuilder = actualQuery.term();
+        assertThat(termQueryBuilder, notNullValue());
 
-        assertThat(actualQueryBuilder, instanceOf(TermQueryBuilder.class));
-
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) actualQueryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(PARTIES_DATE_OF_BIRTH_REFERENCE_PATH));
-        assertThat(termQueryBuilder.value(), is(dateOfBirth));
+        assertThat(termQueryBuilder.field(), is(PARTIES_DATE_OF_BIRTH_REFERENCE_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(dateOfBirth));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstAndOrMiddleNameLeafQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstAndOrMiddleNameLeafQueryBuilderTest.java
@@ -1,26 +1,23 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
+import static co.elastic.clients.elasticsearch._types.query_dsl.Operator.And;
+import static co.elastic.clients.elasticsearch._types.query_dsl.Operator.Or;
+import static co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType.CrossFields;
 import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
 import static java.util.Arrays.asList;
-import static org.elasticsearch.index.query.MultiMatchQueryBuilder.Type.CROSS_FIELDS;
-import static org.elasticsearch.index.query.Operator.AND;
-import static org.elasticsearch.index.query.Operator.OR;
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.hamcrest.collection.IsMapContaining.hasKey;
 
-import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.NestedQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.junit.jupiter.api.Test;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MultiMatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class FirstAndOrMiddleNameLeafQueryBuilderTest {
 
@@ -30,69 +27,69 @@ public class FirstAndOrMiddleNameLeafQueryBuilderTest {
 
         final FirstAndOrMiddleNameLeafQueryBuilder firstAndOrMiddleNameLeafQueryBuilder = new FirstAndOrMiddleNameLeafQueryBuilder("John", null);
 
-        final QueryBuilder actualQueryBuilder = firstAndOrMiddleNameLeafQueryBuilder.nestedPartiesBuilder();
+        final Query.Builder actualQueryBuilder = firstAndOrMiddleNameLeafQueryBuilder.nestedPartiesBuilder();
 
         assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(NestedQueryBuilder.class));
+        final NestedQuery actualNestedQueryBuilder = actualQueryBuilder.build().nested();
+        assertThat(actualNestedQueryBuilder, notNullValue());
 
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) actualQueryBuilder;
-        assertThat(actualNestedQueryBuilder.getName(), is("nested"));
-        assertThat(actualNestedQueryBuilder.query(), instanceOf((BoolQueryBuilder.class)));
 
-        final BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        assertThat(actualNestedQueryBuilder.query().bool(), notNullValue());
+
+        final BoolQuery boolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(boolQueryBuilder.should(), hasSize(5));
 
-        final QueryBuilder builder = boolQueryBuilder.should().get(0);
-        assertThat(builder, instanceOf(BoolQueryBuilder.class));
+        final Query builder = boolQueryBuilder.should().get(0);
+        assertThat(builder.bool(), notNullValue());
 
-        final BoolQueryBuilder shouldQueryBuilder1 = (BoolQueryBuilder) boolQueryBuilder.should().get(0);
-        final BoolQueryBuilder shouldQueryBuilder2 = (BoolQueryBuilder) boolQueryBuilder.should().get(1);
-        final BoolQueryBuilder shouldQueryBuilder3 = (BoolQueryBuilder) boolQueryBuilder.should().get(2);
-        final BoolQueryBuilder shouldQueryBuilder4 = (BoolQueryBuilder) boolQueryBuilder.should().get(3);
-        final BoolQueryBuilder shouldQueryBuilder5 = (BoolQueryBuilder) boolQueryBuilder.should().get(4);
+        final BoolQuery shouldQueryBuilder1 = boolQueryBuilder.should().get(0).bool();
+        final BoolQuery shouldQueryBuilder2 = boolQueryBuilder.should().get(1).bool();
+        final BoolQuery shouldQueryBuilder3 = boolQueryBuilder.should().get(2).bool();
+        final BoolQuery shouldQueryBuilder4 = boolQueryBuilder.should().get(3).bool();
+        final BoolQuery shouldQueryBuilder5 = boolQueryBuilder.should().get(4).bool();
 
         assertThat(shouldQueryBuilder1.must(), hasSize(1));
-        assertThat(shouldQueryBuilder1.must().get(0), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder1.must().get(0).match(), notNullValue());
 
-        MatchQueryBuilder matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.firstName"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        MatchQuery matchQueryBuilder = shouldQueryBuilder1.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.firstName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
         assertThat(shouldQueryBuilder2.must(), hasSize(1));
-        assertThat(shouldQueryBuilder2.must().get(0), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder2.must().get(0).match(), notNullValue());
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.firstName"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.firstName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
-        MultiMatchQueryBuilder multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder3.must().get(0);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.firstName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(not(hasKey("parties.middleName"))));
-        assertThat(multiMatchQueryBuilder.value(), is("John"));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(AND));
+        MultiMatchQuery multiMatchQueryBuilder = shouldQueryBuilder3.must().get(0).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.firstName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields().stream().anyMatch( v -> v.startsWith("parties.middleName")), is(false));
+        assertThat(multiMatchQueryBuilder.query(), is("John"));
+        assertThat(multiMatchQueryBuilder.type(), is(CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(And));
         assertThat(multiMatchQueryBuilder.boost(), is(0.4F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder4.must().get(0);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.firstName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(not(hasKey("parties.middleName"))));
-        assertThat(multiMatchQueryBuilder.value(), is("John"));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(OR));
+        multiMatchQueryBuilder = shouldQueryBuilder4.must().get(0).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.firstName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields().stream().anyMatch( v -> v.startsWith("parties.middleName")), is(false));
+        assertThat(multiMatchQueryBuilder.query(), is("John"));
+        assertThat(multiMatchQueryBuilder.type(), is(CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(Or));
         assertThat(multiMatchQueryBuilder.boost(), is(0.3F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder5.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.firstName.ngrammed"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
+        matchQueryBuilder = shouldQueryBuilder5.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.firstName.ngrammed"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
         assertThat(matchQueryBuilder.boost(), is(1.7F));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
@@ -104,73 +101,73 @@ public class FirstAndOrMiddleNameLeafQueryBuilderTest {
 
         final FirstAndOrMiddleNameLeafQueryBuilder firstAndOrMiddleNameLeafQueryBuilder = new FirstAndOrMiddleNameLeafQueryBuilder("John", null);
 
-        final QueryBuilder actualQueryBuilder = firstAndOrMiddleNameLeafQueryBuilder.nestedPartyAliasesBuilder();
+        final Query.Builder actualQueryBuilder = firstAndOrMiddleNameLeafQueryBuilder.nestedPartyAliasesBuilder();
 
         assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(NestedQueryBuilder.class));
+        final NestedQuery topLevelNestedQueryBuilder = actualQueryBuilder.build().nested();
+        assertThat(topLevelNestedQueryBuilder, notNullValue());
 
-        final NestedQueryBuilder topLevelNestedQueryBuilder = (NestedQueryBuilder) actualQueryBuilder;
-        assertThat(topLevelNestedQueryBuilder.getName(), is("nested"));
-        assertThat(topLevelNestedQueryBuilder.query(), instanceOf((NestedQueryBuilder.class)));
 
-        assertThat(topLevelNestedQueryBuilder.query(), instanceOf((NestedQueryBuilder.class)));
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) topLevelNestedQueryBuilder.query();
+        assertThat(topLevelNestedQueryBuilder.query().nested(), notNullValue());
 
-        final BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        assertThat(topLevelNestedQueryBuilder.query().nested(), notNullValue());
+        final NestedQuery actualNestedQueryBuilder = topLevelNestedQueryBuilder.query().nested();
+
+        final BoolQuery boolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(boolQueryBuilder.should(), hasSize(5));
 
 
-        final QueryBuilder builder = boolQueryBuilder.should().get(0);
-        assertThat(builder, instanceOf(BoolQueryBuilder.class));
+        final Query builder = boolQueryBuilder.should().get(0);
+        assertThat(builder.bool(), notNullValue());
 
-        final BoolQueryBuilder shouldQueryBuilder1 = (BoolQueryBuilder) boolQueryBuilder.should().get(0);
-        final BoolQueryBuilder shouldQueryBuilder2 = (BoolQueryBuilder) boolQueryBuilder.should().get(1);
-        final BoolQueryBuilder shouldQueryBuilder3 = (BoolQueryBuilder) boolQueryBuilder.should().get(2);
-        final BoolQueryBuilder shouldQueryBuilder4 = (BoolQueryBuilder) boolQueryBuilder.should().get(3);
-        final BoolQueryBuilder shouldQueryBuilder5 = (BoolQueryBuilder) boolQueryBuilder.should().get(4);
+        final BoolQuery shouldQueryBuilder1 = boolQueryBuilder.should().get(0).bool();
+        final BoolQuery shouldQueryBuilder2 = boolQueryBuilder.should().get(1).bool();
+        final BoolQuery shouldQueryBuilder3 = boolQueryBuilder.should().get(2).bool();
+        final BoolQuery shouldQueryBuilder4 = boolQueryBuilder.should().get(3).bool();
+        final BoolQuery shouldQueryBuilder5 = boolQueryBuilder.should().get(4).bool();
 
         assertThat(shouldQueryBuilder1.must(), hasSize(1));
-        assertThat(shouldQueryBuilder1.must().get(0), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder1.must().get(0).match(), notNullValue());
 
-        MatchQueryBuilder matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.firstName"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        MatchQuery matchQueryBuilder = shouldQueryBuilder1.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.firstName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
         assertThat(shouldQueryBuilder2.must(), hasSize(1));
-        assertThat(shouldQueryBuilder2.must().get(0), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder2.must().get(0).match(), notNullValue());
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.firstName"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.firstName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
-        MultiMatchQueryBuilder multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder3.must().get(0);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.aliases.firstName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(not(hasKey("parties.aliases.middleName"))));
-        assertThat(multiMatchQueryBuilder.value(), is("John"));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(AND));
+        MultiMatchQuery multiMatchQueryBuilder = shouldQueryBuilder3.must().get(0).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.aliases.firstName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields().stream().anyMatch( v -> v.startsWith("parties.aliases.middleName")), is(false));
+        assertThat(multiMatchQueryBuilder.query(), is("John"));
+        assertThat(multiMatchQueryBuilder.type(), is(CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(And));
         assertThat(multiMatchQueryBuilder.boost(), is(0.4F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder4.must().get(0);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.aliases.firstName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(not(hasKey("parties.aliases.middleName"))));
-        assertThat(multiMatchQueryBuilder.value(), is("John"));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(OR));
+        multiMatchQueryBuilder = shouldQueryBuilder4.must().get(0).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.aliases.firstName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields().stream().anyMatch( v -> v.startsWith("parties.aliases.middleName")), is(false));
+        assertThat(multiMatchQueryBuilder.query(), is("John"));
+        assertThat(multiMatchQueryBuilder.type(), is(CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(Or));
         assertThat(multiMatchQueryBuilder.boost(), is(0.3F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder5.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.firstName.ngrammed"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
+        matchQueryBuilder = shouldQueryBuilder5.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.firstName.ngrammed"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
         assertThat(matchQueryBuilder.boost(), is(1.7F));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
@@ -181,85 +178,85 @@ public class FirstAndOrMiddleNameLeafQueryBuilderTest {
 
         final FirstAndOrMiddleNameLeafQueryBuilder firstAndOrMiddleNameLeafQueryBuilder = new FirstAndOrMiddleNameLeafQueryBuilder("John Smith", null);
 
-        final QueryBuilder actualQueryBuilder = firstAndOrMiddleNameLeafQueryBuilder.nestedPartiesBuilder();
+        final Query.Builder actualQueryBuilder = firstAndOrMiddleNameLeafQueryBuilder.nestedPartiesBuilder();
 
         assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(NestedQueryBuilder.class));
+        final NestedQuery actualNestedQueryBuilder = actualQueryBuilder.build().nested();
+        assertThat(actualNestedQueryBuilder, notNullValue());
 
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) actualQueryBuilder;
-        assertThat(actualNestedQueryBuilder.getName(), is("nested"));
-        assertThat(actualNestedQueryBuilder.query(), instanceOf((BoolQueryBuilder.class)));
+        
+        assertThat(actualNestedQueryBuilder.query().bool(), notNullValue());
 
-        final BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        final BoolQuery boolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(boolQueryBuilder.should(), hasSize(5));
 
-        final QueryBuilder builder = boolQueryBuilder.should().get(0);
-        assertThat(builder, instanceOf(BoolQueryBuilder.class));
+        final Query builder = boolQueryBuilder.should().get(0);
+        assertThat(builder.bool(), notNullValue());
 
-        final BoolQueryBuilder shouldQueryBuilder1 = (BoolQueryBuilder) boolQueryBuilder.should().get(0);
-        final BoolQueryBuilder shouldQueryBuilder2 = (BoolQueryBuilder) boolQueryBuilder.should().get(1);
-        final BoolQueryBuilder shouldQueryBuilder3 = (BoolQueryBuilder) boolQueryBuilder.should().get(2);
-        final BoolQueryBuilder shouldQueryBuilder4 = (BoolQueryBuilder) boolQueryBuilder.should().get(3);
-        final BoolQueryBuilder shouldQueryBuilder5 = (BoolQueryBuilder) boolQueryBuilder.should().get(4);
+        final BoolQuery shouldQueryBuilder1 = boolQueryBuilder.should().get(0).bool();
+        final BoolQuery shouldQueryBuilder2 = boolQueryBuilder.should().get(1).bool();
+        final BoolQuery shouldQueryBuilder3 = boolQueryBuilder.should().get(2).bool();
+        final BoolQuery shouldQueryBuilder4 = boolQueryBuilder.should().get(3).bool();
+        final BoolQuery shouldQueryBuilder5 = boolQueryBuilder.should().get(4).bool();
 
         assertThat(shouldQueryBuilder1.must(), hasSize(2));
-        assertThat(shouldQueryBuilder1.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder1.must().get(1), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder1.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder1.must().get(1).match(), notNullValue());
 
-        MatchQueryBuilder matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.firstName"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        MatchQuery matchQueryBuilder = shouldQueryBuilder1.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.firstName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.middleName"));
-        assertThat(matchQueryBuilder.value(), is("Smith"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        matchQueryBuilder = shouldQueryBuilder1.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.middleName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("Smith"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
         assertThat(shouldQueryBuilder2.must(), hasSize(2));
-        assertThat(shouldQueryBuilder2.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder2.must().get(1), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder2.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder2.must().get(1).match(), notNullValue());
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.firstName"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.firstName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.middleName"));
-        assertThat(matchQueryBuilder.value(), is("Smith"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.middleName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("Smith"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
-        MultiMatchQueryBuilder multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder3.must().get(0);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.firstName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.middleName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.value(), is("John Smith"));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(AND));
+        MultiMatchQuery multiMatchQueryBuilder = shouldQueryBuilder3.must().get(0).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.firstName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.middleName^2.0f")));
+        assertThat(multiMatchQueryBuilder.query(), is("John Smith"));
+        assertThat(multiMatchQueryBuilder.type(), is(CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(And));
         assertThat(multiMatchQueryBuilder.boost(), is(0.4F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder4.must().get(0);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.firstName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.middleName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.value(), is("John Smith"));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(OR));
+        multiMatchQueryBuilder = shouldQueryBuilder4.must().get(0).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.firstName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.middleName^2.0f")));
+        assertThat(multiMatchQueryBuilder.query(), is("John Smith"));
+        assertThat(multiMatchQueryBuilder.type(), is(CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(Or));
         assertThat(multiMatchQueryBuilder.boost(), is(0.3F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder5.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.firstName.ngrammed"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
+        matchQueryBuilder = shouldQueryBuilder5.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.firstName.ngrammed"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
         assertThat(matchQueryBuilder.boost(), is(1.7F));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
@@ -271,88 +268,87 @@ public class FirstAndOrMiddleNameLeafQueryBuilderTest {
 
         final FirstAndOrMiddleNameLeafQueryBuilder firstAndOrMiddleNameLeafQueryBuilder = new FirstAndOrMiddleNameLeafQueryBuilder("John Smith", null);
 
-        final QueryBuilder actualQueryBuilder = firstAndOrMiddleNameLeafQueryBuilder.nestedPartyAliasesBuilder();
+        final Query.Builder actualQueryBuilder = firstAndOrMiddleNameLeafQueryBuilder.nestedPartyAliasesBuilder();
 
         assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(NestedQueryBuilder.class));
+        final NestedQuery topLevelNestedQueryBuilder = actualQueryBuilder.build().nested();
+        assertThat(topLevelNestedQueryBuilder, notNullValue());
 
-        final NestedQueryBuilder topLevelNestedQueryBuilder = (NestedQueryBuilder) actualQueryBuilder;
-        assertThat(topLevelNestedQueryBuilder.getName(), is("nested"));
-        assertThat(topLevelNestedQueryBuilder.query(), instanceOf((NestedQueryBuilder.class)));
+        assertThat(topLevelNestedQueryBuilder.query().nested(), notNullValue());
 
-        assertThat(topLevelNestedQueryBuilder.query(), instanceOf((NestedQueryBuilder.class)));
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) topLevelNestedQueryBuilder.query();
+        assertThat(topLevelNestedQueryBuilder.query().nested(), notNullValue());
+        final NestedQuery actualNestedQueryBuilder = topLevelNestedQueryBuilder.query().nested();
 
-        final BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        final BoolQuery boolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(boolQueryBuilder.should(), hasSize(5));
 
-        final QueryBuilder builder = boolQueryBuilder.should().get(0);
-        assertThat(builder, instanceOf(BoolQueryBuilder.class));
+        final Query builder = boolQueryBuilder.should().get(0);
+        assertThat(builder.bool(), notNullValue());
 
-        final BoolQueryBuilder shouldQueryBuilder1 = (BoolQueryBuilder) boolQueryBuilder.should().get(0);
-        final BoolQueryBuilder shouldQueryBuilder2 = (BoolQueryBuilder) boolQueryBuilder.should().get(1);
-        final BoolQueryBuilder shouldQueryBuilder3 = (BoolQueryBuilder) boolQueryBuilder.should().get(2);
-        final BoolQueryBuilder shouldQueryBuilder4 = (BoolQueryBuilder) boolQueryBuilder.should().get(3);
-        final BoolQueryBuilder shouldQueryBuilder5 = (BoolQueryBuilder) boolQueryBuilder.should().get(4);
+        final BoolQuery shouldQueryBuilder1 = boolQueryBuilder.should().get(0).bool();
+        final BoolQuery shouldQueryBuilder2 = boolQueryBuilder.should().get(1).bool();
+        final BoolQuery shouldQueryBuilder3 = boolQueryBuilder.should().get(2).bool();
+        final BoolQuery shouldQueryBuilder4 = boolQueryBuilder.should().get(3).bool();
+        final BoolQuery shouldQueryBuilder5 = boolQueryBuilder.should().get(4).bool();
 
         assertThat(shouldQueryBuilder1.must(), hasSize(2));
-        assertThat(shouldQueryBuilder1.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder1.must().get(1), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder1.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder1.must().get(1).match(), notNullValue());
 
-        MatchQueryBuilder matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.firstName"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        MatchQuery matchQueryBuilder = shouldQueryBuilder1.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.firstName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.middleName"));
-        assertThat(matchQueryBuilder.value(), is("Smith"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        matchQueryBuilder = shouldQueryBuilder1.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.middleName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("Smith"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
         assertThat(shouldQueryBuilder2.must(), hasSize(2));
-        assertThat(shouldQueryBuilder2.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder2.must().get(1), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder2.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder2.must().get(1).match(), notNullValue());
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.firstName"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.firstName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.middleName"));
-        assertThat(matchQueryBuilder.value(), is("Smith"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.middleName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("Smith"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
-        MultiMatchQueryBuilder multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder3.must().get(0);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.aliases.firstName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.aliases.middleName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.value(), is("John Smith"));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(AND));
+        MultiMatchQuery multiMatchQueryBuilder = shouldQueryBuilder3.must().get(0).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.aliases.firstName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.aliases.middleName^2.0f")));
+        assertThat(multiMatchQueryBuilder.query(), is("John Smith"));
+        assertThat(multiMatchQueryBuilder.type(), is(CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(And));
         assertThat(multiMatchQueryBuilder.boost(), is(0.4F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder4.must().get(0);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.aliases.firstName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.aliases.middleName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.value(), is("John Smith"));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(OR));
+        multiMatchQueryBuilder =  shouldQueryBuilder4.must().get(0).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.aliases.firstName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.aliases.middleName^2.0f")));
+        assertThat(multiMatchQueryBuilder.query(), is("John Smith"));
+        assertThat(multiMatchQueryBuilder.type(), is(CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(Or));
         assertThat(multiMatchQueryBuilder.boost(), is(0.3F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder5.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.firstName.ngrammed"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
+        matchQueryBuilder = shouldQueryBuilder5.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.firstName.ngrammed"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
         assertThat(matchQueryBuilder.boost(), is(1.7F));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
@@ -361,117 +357,117 @@ public class FirstAndOrMiddleNameLeafQueryBuilderTest {
     @Test
     public void shouldCreateValidBuilderForFirstOrMiddleNameAndAdditionalBuilder() {
 
-        final QueryBuilder additionalBuilder = new PostCodeQueryBuilder().getQueryBuilderBy("AB1 2CD");
-        final FirstAndOrMiddleNameLeafQueryBuilder firstAndOrMiddleNameLeafQueryBuilder = new FirstAndOrMiddleNameLeafQueryBuilder("John Smith", asList(additionalBuilder));
+        final Query additionalQuery = new PostCodeQueryBuilder().getQueryBuilderBy("AB1 2CD");
+        final FirstAndOrMiddleNameLeafQueryBuilder firstAndOrMiddleNameLeafQueryBuilder = new FirstAndOrMiddleNameLeafQueryBuilder("John Smith", asList(additionalQuery));
 
-        final QueryBuilder actualQueryBuilder = firstAndOrMiddleNameLeafQueryBuilder.nestedPartiesBuilder();
+        final Query.Builder actualQueryBuilder = firstAndOrMiddleNameLeafQueryBuilder.nestedPartiesBuilder();
 
         assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(NestedQueryBuilder.class));
+        final NestedQuery actualNestedQueryBuilder = actualQueryBuilder.build().nested();
+        assertThat(actualNestedQueryBuilder, notNullValue());
 
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) actualQueryBuilder;
-        assertThat(actualNestedQueryBuilder.getName(), is("nested"));
-        assertThat(actualNestedQueryBuilder.query(), instanceOf((BoolQueryBuilder.class)));
+        
+        assertThat(actualNestedQueryBuilder.query().bool(), notNullValue());
 
-        final BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        final BoolQuery boolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(boolQueryBuilder.should(), hasSize(5));
 
-        final QueryBuilder builder = boolQueryBuilder.should().get(0);
-        assertThat(builder, instanceOf(BoolQueryBuilder.class));
+        final Query builder = boolQueryBuilder.should().get(0);
+        assertThat(builder.bool(), notNullValue());
 
-        final BoolQueryBuilder shouldQueryBuilder1 = (BoolQueryBuilder) boolQueryBuilder.should().get(0);
-        final BoolQueryBuilder shouldQueryBuilder2 = (BoolQueryBuilder) boolQueryBuilder.should().get(1);
-        final BoolQueryBuilder shouldQueryBuilder3 = (BoolQueryBuilder) boolQueryBuilder.should().get(2);
-        final BoolQueryBuilder shouldQueryBuilder4 = (BoolQueryBuilder) boolQueryBuilder.should().get(3);
-        final BoolQueryBuilder shouldQueryBuilder5 = (BoolQueryBuilder) boolQueryBuilder.should().get(4);
+        final BoolQuery shouldQueryBuilder1 = boolQueryBuilder.should().get(0).bool();
+        final BoolQuery shouldQueryBuilder2 = boolQueryBuilder.should().get(1).bool();
+        final BoolQuery shouldQueryBuilder3 = boolQueryBuilder.should().get(2).bool();
+        final BoolQuery shouldQueryBuilder4 = boolQueryBuilder.should().get(3).bool();
+        final BoolQuery shouldQueryBuilder5 = boolQueryBuilder.should().get(4).bool();
 
         assertThat(shouldQueryBuilder1.must(), hasSize(3));
-        assertThat(shouldQueryBuilder1.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder1.must().get(1), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder1.must().get(2), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder1.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder1.must().get(1).match(), notNullValue());
+        assertThat(shouldQueryBuilder1.must().get(2).match(), notNullValue());
 
-        MatchQueryBuilder matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(0);
+        MatchQuery matchQueryBuilder = shouldQueryBuilder1.must().get(0).match();
         assertPostCodeQueryBuilder(matchQueryBuilder);
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.firstName"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        matchQueryBuilder = shouldQueryBuilder1.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.firstName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(2);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.middleName"));
-        assertThat(matchQueryBuilder.value(), is("Smith"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        matchQueryBuilder = shouldQueryBuilder1.must().get(2).match();
+        assertThat(matchQueryBuilder.field(), is("parties.middleName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("Smith"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
         assertThat(shouldQueryBuilder2.must(), hasSize(3));
-        assertThat(shouldQueryBuilder2.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder2.must().get(1), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder2.must().get(2), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder2.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder2.must().get(1).match(), notNullValue());
+        assertThat(shouldQueryBuilder2.must().get(2).match(), notNullValue());
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(0);
+        matchQueryBuilder = shouldQueryBuilder2.must().get(0).match();
         assertPostCodeQueryBuilder(matchQueryBuilder);
 
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.firstName"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.firstName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(2);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.middleName"));
-        assertThat(matchQueryBuilder.value(), is("Smith"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(2).match();
+        assertThat(matchQueryBuilder.field(), is("parties.middleName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("Smith"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder3.must().get(0);
+        matchQueryBuilder = shouldQueryBuilder3.must().get(0).match();
         assertPostCodeQueryBuilder(matchQueryBuilder);
 
-        MultiMatchQueryBuilder multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder3.must().get(1);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.firstName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.middleName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.value(), is("John Smith"));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(AND));
+        MultiMatchQuery multiMatchQueryBuilder = shouldQueryBuilder3.must().get(1).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.firstName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.middleName^2.0f")));
+        assertThat(multiMatchQueryBuilder.query(), is("John Smith"));
+        assertThat(multiMatchQueryBuilder.type(), is(CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(And));
         assertThat(multiMatchQueryBuilder.boost(), is(0.4F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder4.must().get(0);
+        matchQueryBuilder = shouldQueryBuilder4.must().get(0).match();
         assertPostCodeQueryBuilder(matchQueryBuilder);
 
-        multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder4.must().get(1);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.firstName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.middleName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.value(), is("John Smith"));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(OR));
+        multiMatchQueryBuilder = shouldQueryBuilder4.must().get(1).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.firstName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.middleName^2.0f")));
+        assertThat(multiMatchQueryBuilder.query(), is("John Smith"));
+        assertThat(multiMatchQueryBuilder.type(), is(CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(Or));
         assertThat(multiMatchQueryBuilder.boost(), is(0.3F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder5.must().get(0);
+        matchQueryBuilder = shouldQueryBuilder5.must().get(0).match();
         assertPostCodeQueryBuilder(matchQueryBuilder);
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder5.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.firstName.ngrammed"));
-        assertThat(matchQueryBuilder.value(), is("John"));
-        assertThat(matchQueryBuilder.operator(), is(OR));
+        matchQueryBuilder = shouldQueryBuilder5.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.firstName.ngrammed"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("John"));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
         assertThat(matchQueryBuilder.boost(), is(1.7F));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
     }
 
 
-    private void assertPostCodeQueryBuilder(final MatchQueryBuilder matchQueryBuilder) {
-        assertThat(matchQueryBuilder.fieldName(), is("parties.postCode"));
-        assertThat(matchQueryBuilder.value(), is("AB1 2CD"));
-        assertThat(matchQueryBuilder.operator(), is(AND));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+    private void assertPostCodeQueryBuilder(final MatchQuery matchQueryBuilder) {
+        assertThat(matchQueryBuilder.field(), is("parties.postCode"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("AB1 2CD"));
+        assertThat(matchQueryBuilder.operator(), is(And));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
     }
 

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstNameSearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/FirstNameSearchQueryBuilderTest.java
@@ -1,13 +1,12 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.FIRST_NAME_INDEX;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,15 +22,13 @@ public class FirstNameSearchQueryBuilderTest {
     public void shouldCreateValidBuilderForExactFirstName() {
         final String firstName = "firstName";
 
-        final QueryBuilder actualQueryBuilder = firstNameSearchQueryBuilder.getQueryBuilderBy(firstName);
+        final Query actualQuery = firstNameSearchQueryBuilder.getQueryBuilderBy(firstName);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
+        assertThat(actualQuery, is(notNullValue()));
+        final TermQuery termQueryBuilder = actualQuery.term();
+        assertThat(termQueryBuilder, notNullValue());
 
-        assertThat(actualQueryBuilder, instanceOf(TermQueryBuilder.class));
-
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) actualQueryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(FIRST_NAME_INDEX));
-        assertThat(termQueryBuilder.value(), is(firstName));
+        assertThat(termQueryBuilder.field(), is(FIRST_NAME_INDEX));
+        assertThat(termQueryBuilder.value().stringValue(), is(firstName));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HasOffenceQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HasOffenceQueryBuilderTest.java
@@ -1,21 +1,20 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
+import static co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode.Avg;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.withJsonPath;
-import static org.apache.lucene.search.join.ScoreMode.Avg;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.OFFENCES_NESTED_PATH;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.ExistsQueryBuilder;
-import org.elasticsearch.index.query.NestedQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ExistsQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import org.junit.jupiter.api.Test;
 
 public class HasOffenceQueryBuilderTest {
@@ -48,30 +47,30 @@ public class HasOffenceQueryBuilderTest {
     public void shouldReturnValidNestedQueryBuilderReferenceWhenOffenceExists() {
         final boolean hasOffence = true;
 
-        final QueryBuilder actualQueryBuilder = target.getQueryBuilderBy(hasOffence);
+        final Query actualQuery = target.getQueryBuilderBy(hasOffence);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder.toString(), isJson(allOf(
+        assertThat(actualQuery, is(notNullValue()));
+        assertThat(actualQuery.toString().substring(7), isJson(allOf(
                 withJsonPath("nested.path", equalTo(OFFENCES_NESTED_PATH)),
                 withJsonPath("nested.score_mode", equalTo(Avg.name().toLowerCase())),
                 withJsonPath("nested.query.bool.must", hasSize(1)),
                 withJsonPath("nested.query.bool.must[0].exists.field", equalTo(OFFENCES_NESTED_PATH))
         )));
 
-        assertThat(actualQueryBuilder, is(instanceOf(NestedQueryBuilder.class)));
+        assertThat(actualQuery.nested(), notNullValue());
 
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) actualQueryBuilder;
+        final NestedQuery actualNestedQueryBuilder = actualQuery.nested();
         assertThat(actualNestedQueryBuilder.scoreMode(), is(Avg));
 
-        final BoolQueryBuilder innedBoolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        final BoolQuery innedBoolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(innedBoolQueryBuilder.mustNot(), hasSize(0));
         assertThat(innedBoolQueryBuilder.should(), hasSize(0));
         assertThat(innedBoolQueryBuilder.must(), hasSize(1));
 
-        final QueryBuilder firstMust = innedBoolQueryBuilder.must().get(0);
-        assertThat(firstMust, is(instanceOf(ExistsQueryBuilder.class)));
-        final ExistsQueryBuilder actualExistsQueryBuilder = (ExistsQueryBuilder) firstMust;
-        assertThat(actualExistsQueryBuilder.fieldName(), is(OFFENCES_NESTED_PATH));
+        final Query firstMust = innedBoolQueryBuilder.must().get(0);
+        assertThat(firstMust.exists(), notNullValue());
+        final ExistsQuery actualExistsQueryBuilder = firstMust.exists();
+        assertThat(actualExistsQueryBuilder.field(), is(OFFENCES_NESTED_PATH));
     }
 
     /**
@@ -100,29 +99,29 @@ public class HasOffenceQueryBuilderTest {
     public void shouldReturnValidNestedQueryBuilderReferenceWhenOffenceDoesNotExists() {
         final boolean hasOffence = false;
 
-        final QueryBuilder actualQueryBuilder = target.getQueryBuilderBy(hasOffence);
+        final Query actualQuery = target.getQueryBuilderBy(hasOffence);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder.toString(), isJson(allOf(
+        assertThat(actualQuery, is(notNullValue()));
+        assertThat(actualQuery.toString().substring(7), isJson(allOf(
                 withJsonPath("nested.path", equalTo(OFFENCES_NESTED_PATH)),
                 withJsonPath("nested.score_mode", equalTo(Avg.name().toLowerCase())),
                 withJsonPath("nested.query.bool.must_not", hasSize(1)),
                 withJsonPath("nested.query.bool.must_not[0].exists.field", equalTo(OFFENCES_NESTED_PATH))
         )));
 
-        assertThat(actualQueryBuilder, is(instanceOf(NestedQueryBuilder.class)));
+        assertThat(actualQuery.nested(), notNullValue());
 
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) actualQueryBuilder;
+        final NestedQuery actualNestedQueryBuilder = actualQuery.nested();
         assertThat(actualNestedQueryBuilder.scoreMode(), is(Avg));
 
-        final BoolQueryBuilder innedBoolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        final BoolQuery innedBoolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(innedBoolQueryBuilder.mustNot(), hasSize(1));
         assertThat(innedBoolQueryBuilder.should(), hasSize(0));
         assertThat(innedBoolQueryBuilder.must(), hasSize(0));
 
-        final QueryBuilder firstMustNot = innedBoolQueryBuilder.mustNot().get(0);
-        assertThat(firstMustNot, is(instanceOf(ExistsQueryBuilder.class)));
-        final ExistsQueryBuilder actualExistsQueryBuilder = (ExistsQueryBuilder) firstMustNot;
-        assertThat(actualExistsQueryBuilder.fieldName(), is(OFFENCES_NESTED_PATH));
+        final Query firstMustNot = innedBoolQueryBuilder.mustNot().get(0);
+        assertThat(firstMustNot.exists(), notNullValue());
+        final ExistsQuery actualExistsQueryBuilder = firstMustNot.exists();
+        assertThat(actualExistsQueryBuilder.field(), is(OFFENCES_NESTED_PATH));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingDateSearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingDateSearchQueryBuilderTest.java
@@ -1,17 +1,16 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static uk.gov.moj.cpp.unifiedsearch.query.builders.utils.HearingDateUtil.stringToDate;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.HEARING_DAY_REFERENCE_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.RangeQueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 
 public class HearingDateSearchQueryBuilderTest {
 
@@ -26,31 +25,29 @@ public class HearingDateSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForHearingDateFrom() {
         final String hearingDateFrom = "2019-04-19";
         final String hearingDateTo = "";
-        final QueryBuilder actualQueryBuilder = hearingDateSearchQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
+        final Query actualQueryBuilder = hearingDateSearchQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
 
         assertThat(actualQueryBuilder, is(notNullValue()));
 
-        assertThat(actualQueryBuilder, instanceOf(TermQueryBuilder.class));
+        assertThat(actualQueryBuilder.term(), notNullValue());
 
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) actualQueryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(HEARING_DAY_REFERENCE_PATH));
-        assertThat(termQueryBuilder.value(), is(hearingDateFrom));
+        final TermQuery termQueryBuilder = actualQueryBuilder.term();
+        assertThat(termQueryBuilder.field(), is(HEARING_DAY_REFERENCE_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(hearingDateFrom));
     }
 
     @Test
     public void shouldReturnValidQueryBuilderForHearingDateTo() {
         final String hearingDateFrom = "";
         final String hearingDateTo = "2019-04-19";
-        final QueryBuilder actualQueryBuilder = hearingDateSearchQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
+        final Query actualQueryBuilder = hearingDateSearchQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
 
         assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(TermQueryBuilder.class));
+        assertThat(actualQueryBuilder.term(), notNullValue());
 
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) actualQueryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(HEARING_DAY_REFERENCE_PATH));
-        assertThat(termQueryBuilder.value(), is(hearingDateTo));
+        final TermQuery termQueryBuilder = actualQueryBuilder.term();
+        assertThat(termQueryBuilder.field(), is(HEARING_DAY_REFERENCE_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(hearingDateTo));
     }
 
     @Test
@@ -58,16 +55,15 @@ public class HearingDateSearchQueryBuilderTest {
         final String hearingDateFrom = "2019-04-19";
         final String hearingDateTo = "2019-05-17";
 
-        final QueryBuilder actualQueryBuilder = hearingDateSearchQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
+        final Query actualQueryBuilder = hearingDateSearchQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
 
         assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(RangeQueryBuilder.class));
+        assertThat(actualQueryBuilder.range(), notNullValue());
 
-        final RangeQueryBuilder rangeQueryBuilder = (RangeQueryBuilder) actualQueryBuilder;
-        assertThat(rangeQueryBuilder.getName(), is("range"));
-        assertThat(rangeQueryBuilder.fieldName(), is(HEARING_DAY_REFERENCE_PATH));
-        assertThat(rangeQueryBuilder.from(), is(stringToDate(hearingDateFrom)));
-        assertThat(rangeQueryBuilder.to(), is(stringToDate(hearingDateTo)));
+        final RangeQuery rangeQueryBuilder =actualQueryBuilder.range();
+        assertThat(rangeQueryBuilder.untyped().field(), is(HEARING_DAY_REFERENCE_PATH));
+        assertThat(rangeQueryBuilder.untyped().gte().toString(), is(hearingDateFrom));
+        assertThat(rangeQueryBuilder.untyped().lte().toString(), is(hearingDateTo));
     }
 }
 

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingIdQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingIdQueryBuilderTest.java
@@ -1,18 +1,18 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static java.util.UUID.randomUUID;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.HEARING_ID_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 
 @ExtendWith(MockitoExtension.class)
 public class HearingIdQueryBuilderTest {
@@ -24,15 +24,14 @@ public class HearingIdQueryBuilderTest {
     public void shouldCreateQueryBuilder() {
 
         final String hearingIdFilterBy = randomUUID().toString();
-        final QueryBuilder queryBuilder = hearingIdQueryBuilder.getQueryBuilderBy(hearingIdFilterBy);
+        final Query query = hearingIdQueryBuilder.getQueryBuilderBy(hearingIdFilterBy);
 
-        assertThat(queryBuilder, is(notNullValue()));
-        assertThat(queryBuilder, instanceOf(TermQueryBuilder.class));
+        assertThat(query, is(notNullValue()));
+        final TermQuery termQueryBuilder = query.term();
+        assertThat(termQueryBuilder, notNullValue());
 
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) queryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(HEARING_ID_PATH));
-        assertThat(termQueryBuilder.value(), is(hearingIdFilterBy));
+        assertThat(termQueryBuilder.field(), is(HEARING_ID_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(hearingIdFilterBy));
 
     }
 

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingTypeQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/HearingTypeQueryBuilderTest.java
@@ -1,13 +1,12 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.HEARING_TYPE_ID_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.Test;
 
 public class HearingTypeQueryBuilderTest {
@@ -19,15 +18,14 @@ public class HearingTypeQueryBuilderTest {
     public void shouldCreateQueryBuilder() {
 
         final String hearingTypeToFilterBy = "TEST HEARING TYPE";
-        final QueryBuilder queryBuilder = hearingTypeQueryBuilder.getQueryBuilderBy(hearingTypeToFilterBy);
+        final Query query = hearingTypeQueryBuilder.getQueryBuilderBy(hearingTypeToFilterBy);
 
-        assertThat(queryBuilder, is(notNullValue()));
-        assertThat(queryBuilder, instanceOf(TermQueryBuilder.class));
+        assertThat(query, is(notNullValue()));
+        final TermQuery termQueryBuilder = query.term();
+        assertThat(termQueryBuilder, notNullValue());
 
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) queryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(HEARING_TYPE_ID_PATH));
-        assertThat(termQueryBuilder.value(), is(hearingTypeToFilterBy));
+        assertThat(termQueryBuilder.field(), is(HEARING_TYPE_ID_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(hearingTypeToFilterBy));
 
     }
 

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/JurisdictionTypeQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/JurisdictionTypeQueryBuilderTest.java
@@ -8,9 +8,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_MAGISTRATE_COURT;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_SJP;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.Test;
 
 public class JurisdictionTypeQueryBuilderTest {
@@ -22,24 +22,18 @@ public class JurisdictionTypeQueryBuilderTest {
         final String isSjp = "true";
         final String isMagistrateCourt = "false";
         final String isCrownCourt = "false";
-        final QueryBuilder queryBuilder = jurisdictionTypeQueryBuilder.getQueryBuilderBy(isSjp, isMagistrateCourt, isCrownCourt)    ;
+        final Query query = jurisdictionTypeQueryBuilder.getQueryBuilderBy(isSjp, isMagistrateCourt, isCrownCourt)    ;
 
-        assertThat(queryBuilder, is(notNullValue()));
-        assertThat(queryBuilder, instanceOf((BoolQueryBuilder.class)));
+        assertThat(query, is(notNullValue()));
 
-        final BoolQueryBuilder actualBoolQueryBuilder = (BoolQueryBuilder) queryBuilder;
-        assertThat(actualBoolQueryBuilder.getName(), is("bool"));
+        final BoolQuery actualBoolQueryBuilder = query.bool();
         assertThat(actualBoolQueryBuilder.must(), hasSize(0));
         assertThat(actualBoolQueryBuilder.should(), hasSize(1));
 
-        final QueryBuilder firstShouldClause = actualBoolQueryBuilder.should().get(0);
-
-        assertThat(firstShouldClause, instanceOf(TermQueryBuilder.class));
-
-        final TermQueryBuilder firstTerm = (TermQueryBuilder) firstShouldClause;
-        assertThat(firstTerm.getName(), is("term"));
-        assertThat(firstTerm.fieldName(), is(IS_SJP));
-        assertThat(firstTerm.value(), is(true));
+        final Query firstShouldClause = actualBoolQueryBuilder.should().get(0);
+        final TermQuery firstTerm = firstShouldClause.term();
+        assertThat(firstTerm.field(), is(IS_SJP));
+        assertThat(firstTerm.value().booleanValue(), is(true));
     }
 
     @Test
@@ -49,30 +43,24 @@ public class JurisdictionTypeQueryBuilderTest {
         final String isSjp = "true";
         final String isMagistrateCourt = "true";
         final String isCrownCourt = "false";
-        final QueryBuilder queryBuilder = jurisdictionTypeQueryBuilder.getQueryBuilderBy(isSjp, isMagistrateCourt, isCrownCourt)    ;
+        final Query query = jurisdictionTypeQueryBuilder.getQueryBuilderBy(isSjp, isMagistrateCourt, isCrownCourt)    ;
 
-        assertThat(queryBuilder, is(notNullValue()));
-        assertThat(queryBuilder, instanceOf((BoolQueryBuilder.class)));
+        assertThat(query, is(notNullValue()));
 
-        final BoolQueryBuilder actualBoolQueryBuilder = (BoolQueryBuilder) queryBuilder;
-        assertThat(actualBoolQueryBuilder.getName(), is("bool"));
+        final BoolQuery actualBoolQueryBuilder = query.bool();
         assertThat(actualBoolQueryBuilder.must(), hasSize(0));
         assertThat(actualBoolQueryBuilder.should(), hasSize(2));
 
-        final QueryBuilder firstShouldClause = actualBoolQueryBuilder.should().get(0);
-        final QueryBuilder secondShouldClause = actualBoolQueryBuilder.should().get(1);
+        final Query firstShouldClause = actualBoolQueryBuilder.should().get(0);
+        final Query secondShouldClause = actualBoolQueryBuilder.should().get(1);
 
-        assertThat(firstShouldClause, instanceOf(TermQueryBuilder.class));
-        assertThat(secondShouldClause, instanceOf(TermQueryBuilder.class));
 
-        final TermQueryBuilder firstTerm = (TermQueryBuilder) firstShouldClause;
-        assertThat(firstTerm.getName(), is("term"));
-        assertThat(firstTerm.fieldName(), is(IS_SJP));
-        assertThat(firstTerm.value(), is(true));
+        final TermQuery firstTerm =  firstShouldClause.term();
+        assertThat(firstTerm.field(), is(IS_SJP));
+        assertThat(firstTerm.value().booleanValue(), is(true));
 
-        final TermQueryBuilder secondTerm = (TermQueryBuilder) secondShouldClause;
-        assertThat(secondTerm.getName(), is("term"));
-        assertThat(secondTerm.fieldName(), is(IS_MAGISTRATE_COURT));
-        assertThat(secondTerm.value(), is(true));
+        final TermQuery secondTerm = secondShouldClause.term();
+        assertThat(secondTerm.field(), is(IS_MAGISTRATE_COURT));
+        assertThat(secondTerm.value().booleanValue(), is(true));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastNameSearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastNameSearchQueryBuilderTest.java
@@ -1,13 +1,12 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.LAST_NAME_INDEX;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,15 +22,14 @@ public class LastNameSearchQueryBuilderTest {
     public void shouldCreateValidBuilderForExactLastName() {
         final String lastName = "lastName";
 
-        final QueryBuilder actualQueryBuilder = lastNameSearchQueryBuilder.getQueryBuilderBy(lastName);
+        final Query actualQuery = lastNameSearchQueryBuilder.getQueryBuilderBy(lastName);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
+        assertThat(actualQuery, is(notNullValue()));
+        final TermQuery termQueryBuilder = actualQuery.term();
 
-        assertThat(actualQueryBuilder, instanceOf(TermQueryBuilder.class));
+        assertThat(termQueryBuilder, notNullValue());
 
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) actualQueryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(LAST_NAME_INDEX));
-        assertThat(termQueryBuilder.value(), is(lastName));
+        assertThat(termQueryBuilder.field(), is(LAST_NAME_INDEX));
+        assertThat(termQueryBuilder.value().stringValue(), is(lastName));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastOrOrganisationNameLeafQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/LastOrOrganisationNameLeafQueryBuilderTest.java
@@ -1,23 +1,21 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
+import static co.elastic.clients.elasticsearch._types.query_dsl.Operator.And;
+import static co.elastic.clients.elasticsearch._types.query_dsl.Operator.Or;
 import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
 import static java.util.Arrays.asList;
-import static org.elasticsearch.index.query.MultiMatchQueryBuilder.Type.CROSS_FIELDS;
-import static org.elasticsearch.index.query.Operator.AND;
-import static org.elasticsearch.index.query.Operator.OR;
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsMapContaining.hasEntry;
 
-import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.NestedQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MultiMatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType;
 import org.junit.jupiter.api.Test;
 
 public class LastOrOrganisationNameLeafQueryBuilderTest {
@@ -52,77 +50,76 @@ public class LastOrOrganisationNameLeafQueryBuilderTest {
     private void assertQueryBuilderForNameString(final String nameString) {
         final LastOrOrganisationNameLeafQueryBuilder lastOrOrganisationNameLeafQueryBuilder = new LastOrOrganisationNameLeafQueryBuilder(nameString, null);
 
-        final QueryBuilder actualQueryBuilder = lastOrOrganisationNameLeafQueryBuilder.nestedPartiesBuilder();
+        final Query.Builder actualQueryBuilder = lastOrOrganisationNameLeafQueryBuilder.nestedPartiesBuilder();
 
         assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(NestedQueryBuilder.class));
+        final NestedQuery actualNestedQueryBuilder = actualQueryBuilder.build().nested();
+        assertThat(actualNestedQueryBuilder, notNullValue());
 
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) actualQueryBuilder;
-        assertThat(actualNestedQueryBuilder.getName(), is("nested"));
-        assertThat(actualNestedQueryBuilder.query(), instanceOf((BoolQueryBuilder.class)));
+        assertThat(actualNestedQueryBuilder.query().bool(), notNullValue());
 
-        final BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        final BoolQuery boolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(boolQueryBuilder.should(), hasSize(4));
 
-        final QueryBuilder builder = boolQueryBuilder.should().get(0);
-        assertThat(builder, instanceOf(BoolQueryBuilder.class));
+        final Query builder = boolQueryBuilder.should().get(0);
+        assertThat(builder.bool(), notNullValue());
 
 
-        final BoolQueryBuilder shouldQueryBuilder1 = (BoolQueryBuilder) boolQueryBuilder.should().get(0);
-        final BoolQueryBuilder shouldQueryBuilder2 = (BoolQueryBuilder) boolQueryBuilder.should().get(1);
-        final BoolQueryBuilder shouldQueryBuilder3 = (BoolQueryBuilder) boolQueryBuilder.should().get(2);
-        final BoolQueryBuilder shouldQueryBuilder4 = (BoolQueryBuilder) boolQueryBuilder.should().get(3);
+        final BoolQuery shouldQueryBuilder1 = boolQueryBuilder.should().get(0).bool();
+        final BoolQuery shouldQueryBuilder2 = boolQueryBuilder.should().get(1).bool();
+        final BoolQuery shouldQueryBuilder3 = boolQueryBuilder.should().get(2).bool();
+        final BoolQuery shouldQueryBuilder4 = boolQueryBuilder.should().get(3).bool();
 
         assertThat(shouldQueryBuilder1.must(), hasSize(2));
-        assertThat(shouldQueryBuilder1.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder1.must().get(1), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder1.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder1.must().get(1).match(), notNullValue());
 
-        MatchQueryBuilder matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.lastName"));
-        assertThat(matchQueryBuilder.value(), is(nameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        MatchQuery matchQueryBuilder = shouldQueryBuilder1.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.lastName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(nameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.organisationName"));
-        assertThat(matchQueryBuilder.value(), is(nameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        matchQueryBuilder = shouldQueryBuilder1.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.organisationName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(nameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
         assertThat(shouldQueryBuilder2.must(), hasSize(2));
-        assertThat(shouldQueryBuilder2.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder2.must().get(1), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder2.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder2.must().get(1).match(), notNullValue());
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.lastName"));
-        assertThat(matchQueryBuilder.value(), is(nameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.lastName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(nameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.organisationName"));
-        assertThat(matchQueryBuilder.value(), is(nameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder =  shouldQueryBuilder2.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.organisationName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(nameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
 
-        MultiMatchQueryBuilder multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder3.must().get(0);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.lastName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.organisationName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.value(), is(nameString));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(OR));
+        MultiMatchQuery multiMatchQueryBuilder =  shouldQueryBuilder3.must().get(0).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.lastName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.organisationName^2.0f")));
+        assertThat(multiMatchQueryBuilder.query(), is(nameString));
+        assertThat(multiMatchQueryBuilder.type(), is(TextQueryType.CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(Or));
         assertThat(multiMatchQueryBuilder.boost(), is(0.3F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder4.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.lastName.ngrammed"));
-        assertThat(matchQueryBuilder.value(), is(nameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
+        matchQueryBuilder = shouldQueryBuilder4.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.lastName.ngrammed"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(nameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
         assertThat(matchQueryBuilder.boost(), is(1.7F));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
     }
@@ -130,94 +127,94 @@ public class LastOrOrganisationNameLeafQueryBuilderTest {
 
     private void assertQueryBuilderForNameStringWithAdditionalBuilders(final String nameString) {
 
-        final QueryBuilder additionalBuilder = new PostCodeQueryBuilder().getQueryBuilderBy("AB1 2CD");
-        final LastOrOrganisationNameLeafQueryBuilder lastOrOrganisationNameLeafQueryBuilder = new LastOrOrganisationNameLeafQueryBuilder(nameString, asList(additionalBuilder));
+        final Query additionalQuery = new PostCodeQueryBuilder().getQueryBuilderBy("AB1 2CD");
+        final LastOrOrganisationNameLeafQueryBuilder lastOrOrganisationNameLeafQueryBuilder = new LastOrOrganisationNameLeafQueryBuilder(nameString, asList(additionalQuery));
 
-        final QueryBuilder actualQueryBuilder = lastOrOrganisationNameLeafQueryBuilder.nestedPartiesBuilder();
+        final Query.Builder actualQueryBuilder = lastOrOrganisationNameLeafQueryBuilder.nestedPartiesBuilder();
 
         assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(NestedQueryBuilder.class));
+        final NestedQuery actualNestedQueryBuilder = actualQueryBuilder.build().nested();
+        assertThat(actualNestedQueryBuilder, notNullValue());
 
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) actualQueryBuilder;
-        assertThat(actualNestedQueryBuilder.getName(), is("nested"));
-        assertThat(actualNestedQueryBuilder.query(), instanceOf((BoolQueryBuilder.class)));
 
-        final BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        assertThat(actualNestedQueryBuilder.query().bool(), notNullValue());
+
+        final BoolQuery boolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(boolQueryBuilder.should(), hasSize(4));
 
-        final QueryBuilder builder = boolQueryBuilder.should().get(0);
-        assertThat(builder, instanceOf(BoolQueryBuilder.class));
+        final Query builder = boolQueryBuilder.should().get(0);
+        assertThat(builder.bool(), notNullValue());
 
 
-        final BoolQueryBuilder shouldQueryBuilder1 = (BoolQueryBuilder) boolQueryBuilder.should().get(0);
-        final BoolQueryBuilder shouldQueryBuilder2 = (BoolQueryBuilder) boolQueryBuilder.should().get(1);
-        final BoolQueryBuilder shouldQueryBuilder3 = (BoolQueryBuilder) boolQueryBuilder.should().get(2);
-        final BoolQueryBuilder shouldQueryBuilder4 = (BoolQueryBuilder) boolQueryBuilder.should().get(3);
+        final BoolQuery shouldQueryBuilder1 = boolQueryBuilder.should().get(0).bool();
+        final BoolQuery shouldQueryBuilder2 = boolQueryBuilder.should().get(1).bool();
+        final BoolQuery shouldQueryBuilder3 = boolQueryBuilder.should().get(2).bool();
+        final BoolQuery shouldQueryBuilder4 = boolQueryBuilder.should().get(3).bool();
 
         assertThat(shouldQueryBuilder1.must(), hasSize(3));
-        assertThat(shouldQueryBuilder1.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder1.must().get(1), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder1.must().get(2), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder1.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder1.must().get(1).match(), notNullValue());
+        assertThat(shouldQueryBuilder1.must().get(2).match(), notNullValue());
 
-        MatchQueryBuilder matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(0);
+        MatchQuery matchQueryBuilder = shouldQueryBuilder1.must().get(0).match();
         assertPostCodeQueryBuilder(matchQueryBuilder);
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.lastName"));
-        assertThat(matchQueryBuilder.value(), is(nameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        matchQueryBuilder = shouldQueryBuilder1.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.lastName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(nameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(2);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.organisationName"));
-        assertThat(matchQueryBuilder.value(), is(nameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        matchQueryBuilder = shouldQueryBuilder1.must().get(2).match();
+        assertThat(matchQueryBuilder.field(), is("parties.organisationName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(nameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
         assertThat(shouldQueryBuilder2.must(), hasSize(3));
-        assertThat(shouldQueryBuilder2.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder2.must().get(1), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder2.must().get(1), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder2.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder2.must().get(1).match(), notNullValue());
+        assertThat(shouldQueryBuilder2.must().get(1).match(), notNullValue());
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(0);
+        matchQueryBuilder = shouldQueryBuilder2.must().get(0).match();
         assertPostCodeQueryBuilder(matchQueryBuilder);
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.lastName"));
-        assertThat(matchQueryBuilder.value(), is(nameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.lastName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(nameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(2);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.organisationName"));
-        assertThat(matchQueryBuilder.value(), is(nameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(2).match();
+        assertThat(matchQueryBuilder.field(), is("parties.organisationName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(nameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder3.must().get(0);
+        matchQueryBuilder = shouldQueryBuilder3.must().get(0).match();
         assertPostCodeQueryBuilder(matchQueryBuilder);
 
-        MultiMatchQueryBuilder multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder3.must().get(1);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.lastName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.organisationName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.value(), is(nameString));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(OR));
+        MultiMatchQuery multiMatchQueryBuilder = shouldQueryBuilder3.must().get(1).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.lastName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.organisationName^2.0f")));
+        assertThat(multiMatchQueryBuilder.query(), is(nameString));
+        assertThat(multiMatchQueryBuilder.type(), is(TextQueryType.CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(Or));
         assertThat(multiMatchQueryBuilder.boost(), is(0.3F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder3.must().get(0);
+        matchQueryBuilder = shouldQueryBuilder3.must().get(0).match();
         assertPostCodeQueryBuilder(matchQueryBuilder);
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder4.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.lastName.ngrammed"));
-        assertThat(matchQueryBuilder.value(), is(nameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
+        matchQueryBuilder = shouldQueryBuilder4.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.lastName.ngrammed"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(nameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
         assertThat(matchQueryBuilder.boost(), is(1.7F));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
     }
@@ -227,90 +224,88 @@ public class LastOrOrganisationNameLeafQueryBuilderTest {
 
         final LastOrOrganisationNameLeafQueryBuilder lastOrOrganisationNameLeafQueryBuilder = new LastOrOrganisationNameLeafQueryBuilder(aliasNameString, null);
 
-        final QueryBuilder actualQueryBuilder = lastOrOrganisationNameLeafQueryBuilder.nestedPartyAliasesBuilder();
+        final Query.Builder actualQueryBuilder = lastOrOrganisationNameLeafQueryBuilder.nestedPartyAliasesBuilder();
 
         assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(NestedQueryBuilder.class));
+        final NestedQuery topLevelNestedQueryBuilder = actualQueryBuilder.build().nested();
+        assertThat(topLevelNestedQueryBuilder, notNullValue());
 
-        final NestedQueryBuilder topLevelNestedQueryBuilder = (NestedQueryBuilder) actualQueryBuilder;
-        assertThat(topLevelNestedQueryBuilder.getName(), is("nested"));
-        assertThat(topLevelNestedQueryBuilder.query(), instanceOf((NestedQueryBuilder.class)));
+        assertThat(topLevelNestedQueryBuilder.query().nested(), notNullValue());
 
-        assertThat(topLevelNestedQueryBuilder.query(), instanceOf((NestedQueryBuilder.class)));
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) topLevelNestedQueryBuilder.query();
+        final NestedQuery actualNestedQueryBuilder = topLevelNestedQueryBuilder.query().nested();
 
-        final BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        final BoolQuery boolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(boolQueryBuilder.should(), hasSize(4));
 
-        final QueryBuilder builder = boolQueryBuilder.should().get(0);
-        assertThat(builder, instanceOf(BoolQueryBuilder.class));
+        final Query builder = boolQueryBuilder.should().get(0);
+        assertThat(builder, notNullValue());
 
-        final BoolQueryBuilder shouldQueryBuilder1 = (BoolQueryBuilder) boolQueryBuilder.should().get(0);
-        final BoolQueryBuilder shouldQueryBuilder2 = (BoolQueryBuilder) boolQueryBuilder.should().get(1);
-        final BoolQueryBuilder shouldQueryBuilder3 = (BoolQueryBuilder) boolQueryBuilder.should().get(2);
-        final BoolQueryBuilder shouldQueryBuilder4 = (BoolQueryBuilder) boolQueryBuilder.should().get(3);
+        final BoolQuery shouldQueryBuilder1 = boolQueryBuilder.should().get(0).bool();
+        final BoolQuery shouldQueryBuilder2 = boolQueryBuilder.should().get(1).bool();
+        final BoolQuery shouldQueryBuilder3 = boolQueryBuilder.should().get(2).bool();
+        final BoolQuery shouldQueryBuilder4 = boolQueryBuilder.should().get(3).bool();
 
         assertThat(shouldQueryBuilder1.must(), hasSize(2));
-        assertThat(shouldQueryBuilder1.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder1.must().get(1), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder1.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder1.must().get(1).match(), notNullValue());
 
-        MatchQueryBuilder matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.lastName"));
-        assertThat(matchQueryBuilder.value(), is(aliasNameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        MatchQuery matchQueryBuilder = shouldQueryBuilder1.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.lastName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(aliasNameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder1.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.organisationName"));
-        assertThat(matchQueryBuilder.value(), is(aliasNameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+        matchQueryBuilder = shouldQueryBuilder1.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.organisationName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(aliasNameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
         assertThat(shouldQueryBuilder2.must(), hasSize(2));
-        assertThat(shouldQueryBuilder2.must().get(0), instanceOf((MatchQueryBuilder.class)));
-        assertThat(shouldQueryBuilder2.must().get(1), instanceOf((MatchQueryBuilder.class)));
+        assertThat(shouldQueryBuilder2.must().get(0).match(), notNullValue());
+        assertThat(shouldQueryBuilder2.must().get(1).match(), notNullValue());
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.lastName"));
-        assertThat(matchQueryBuilder.value(), is(aliasNameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.lastName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(aliasNameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder2.must().get(1);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.organisationName"));
-        assertThat(matchQueryBuilder.value(), is(aliasNameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
-        assertThat(matchQueryBuilder.fuzziness(), is(Fuzziness.AUTO));
+        matchQueryBuilder = shouldQueryBuilder2.must().get(1).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.organisationName"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(aliasNameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
+        assertThat(matchQueryBuilder.fuzziness(), is("AUTO"));
 
 
-        MultiMatchQueryBuilder multiMatchQueryBuilder = (MultiMatchQueryBuilder) shouldQueryBuilder3.must().get(0);
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.aliases.lastName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.fields(), is(hasEntry("parties.aliases.organisationName", 2.0F)));
-        assertThat(multiMatchQueryBuilder.value(), is(aliasNameString));
-        assertThat(multiMatchQueryBuilder.type(), is(CROSS_FIELDS));
-        assertThat(multiMatchQueryBuilder.operator(), is(OR));
+        MultiMatchQuery multiMatchQueryBuilder = shouldQueryBuilder3.must().get(0).multiMatch();
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.aliases.lastName^2.0f")));
+        assertThat(multiMatchQueryBuilder.fields(), is(hasItem("parties.aliases.organisationName^2.0f")));
+        assertThat(multiMatchQueryBuilder.query(), is(aliasNameString));
+        assertThat(multiMatchQueryBuilder.type(), is(TextQueryType.CrossFields));
+        assertThat(multiMatchQueryBuilder.operator(), is(Or));
         assertThat(multiMatchQueryBuilder.boost(), is(0.3F));
         assertThat(multiMatchQueryBuilder.fuzziness(), is(nullValue()));
 
-        matchQueryBuilder = (MatchQueryBuilder) shouldQueryBuilder4.must().get(0);
-        assertThat(matchQueryBuilder.fieldName(), is("parties.aliases.lastName.ngrammed"));
-        assertThat(matchQueryBuilder.value(), is(aliasNameString));
-        assertThat(matchQueryBuilder.operator(), is(OR));
+        matchQueryBuilder = shouldQueryBuilder4.must().get(0).match();
+        assertThat(matchQueryBuilder.field(), is("parties.aliases.lastName.ngrammed"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(aliasNameString));
+        assertThat(matchQueryBuilder.operator(), is(nullValue()));
         assertThat(matchQueryBuilder.boost(), is(1.7F));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
 
 
     }
 
-    private void assertPostCodeQueryBuilder(final MatchQueryBuilder matchQueryBuilder) {
-        assertThat(matchQueryBuilder.fieldName(), is("parties.postCode"));
-        assertThat(matchQueryBuilder.value(), is("AB1 2CD"));
-        assertThat(matchQueryBuilder.operator(), is(AND));
-        assertThat(matchQueryBuilder.boost(), is(1.0F));
+    private void assertPostCodeQueryBuilder(final MatchQuery matchQueryBuilder) {
+        assertThat(matchQueryBuilder.field(), is("parties.postCode"));
+        assertThat(matchQueryBuilder.query().stringValue(), is("AB1 2CD"));
+        assertThat(matchQueryBuilder.operator(), is(And));
+        assertThat(matchQueryBuilder.boost(), is(nullValue()));
         assertThat(matchQueryBuilder.fuzziness(), is(nullValue()));
     }
 

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NameSearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NameSearchQueryBuilderTest.java
@@ -6,11 +6,14 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.withoutJsonPath;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
-import org.elasticsearch.index.query.QueryBuilder;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -18,21 +21,21 @@ public class NameSearchQueryBuilderTest {
 
     private NameSearchQueryBuilder builder = new NameSearchQueryBuilder();
 
-    private QueryBuilder partyTypesQueryBuilder;
-    private QueryBuilder dateOfBirthQueryBuilder;
+    private Query partyTypesQuery;
+    private Query dateOfBirthQuery;
 
     @BeforeEach
     public void setUp() {
-        partyTypesQueryBuilder = new PartyTypeSearchQueryBuilder().getQueryBuilderBy("DEFENDANT,APPLICANT");
-        dateOfBirthQueryBuilder = new DateOfBirthSearchQueryBuilder().getQueryBuilderBy("2018-01-01");
+        partyTypesQuery = new PartyTypeSearchQueryBuilder().getQueryBuilderBy("DEFENDANT,APPLICANT");
+        dateOfBirthQuery = new DateOfBirthSearchQueryBuilder().getQueryBuilderBy("2018-01-01");
     }
 
     @Test
     public void shouldReturnValidQueryBuilderForThreeNameComponents() {
 
         final String nameQueryString = "John Allen Smith";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, emptyList());
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, emptyList());
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "John", "Allen", "Smith", queryBuilderJson, 0);
 
@@ -41,8 +44,8 @@ public class NameSearchQueryBuilderTest {
     @Test
     public void shouldReturnValidQueryBuilderForThreeNameComponentsAndPartyTypes() {
         final String nameQueryString = "John Allen Smith";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQueryBuilder, dateOfBirthQueryBuilder));
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQuery, dateOfBirthQuery));
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "John", "Allen", "Smith", queryBuilderJson, 2);
 
@@ -52,8 +55,8 @@ public class NameSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForTwoNameComponents() {
 
         final String nameQueryString = "John Smith";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, emptyList());
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, emptyList());
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "John", null, "Smith", queryBuilderJson, 0);
     }
@@ -62,8 +65,8 @@ public class NameSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForTwoNameComponentsAndPartyTypes() {
 
         final String nameQueryString = "John Smith";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQueryBuilder, dateOfBirthQueryBuilder));
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQuery, dateOfBirthQuery));
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "John", null, "Smith", queryBuilderJson, 2);
     }
@@ -72,8 +75,8 @@ public class NameSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForOneNameComponents() {
 
         final String nameQueryString = "CapGemini";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, emptyList());
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, emptyList());
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "CapGemini", null, null, queryBuilderJson, 0);
 
@@ -83,8 +86,8 @@ public class NameSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForOneNameComponentsAndPartyTypes() {
 
         final String nameQueryString = "CapGemini";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQueryBuilder, dateOfBirthQueryBuilder));
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQuery, dateOfBirthQuery));
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "CapGemini", null, null, queryBuilderJson, 2);
 
@@ -94,8 +97,8 @@ public class NameSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForMultiWordOrgNameComponents() {
 
         final String nameQueryString = "Marks and Spencers";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, emptyList());
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, emptyList());
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "Marks", "and", "Spencers", queryBuilderJson, 0);
     }
@@ -104,8 +107,8 @@ public class NameSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForFiveNameComponents() {
 
         final String nameQueryString = "John Allen De La Smith";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, emptyList());
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, emptyList());
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "John", "Allen", "De", queryBuilderJson, 0);
 
@@ -115,8 +118,8 @@ public class NameSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForFiveNameComponentsAndPartyTypes() {
 
         final String nameQueryString = "John Allen De La Smith";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQueryBuilder));
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQuery));
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "John", "Allen", "De", queryBuilderJson, 1);
 
@@ -126,8 +129,8 @@ public class NameSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForTwoNameWithoutAlias() {
 
         final String nameQueryString = "John Smith";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, emptyList());
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, emptyList());
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "John", null, "Smith", queryBuilderJson, 0);
 
@@ -137,8 +140,8 @@ public class NameSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForTwoNameWithoutAliasAndPartyTypes() {
 
         final String nameQueryString = "John Smith";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQueryBuilder));
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQuery));
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "John", null, "Smith", queryBuilderJson, 1);
 
@@ -148,8 +151,8 @@ public class NameSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForTwoNameWithoutAliasAndDateOfBirth() {
 
         final String nameQueryString = "John Smith";
-        final QueryBuilder queryBuilder = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQueryBuilder, dateOfBirthQueryBuilder));
-        final String queryBuilderJson = queryBuilder.toString();
+        final Query query = builder.getQueryBuilderBy(nameQueryString, of(partyTypesQuery, dateOfBirthQuery));
+        final String queryBuilderJson = query.toString().substring(7);
 
         validateResponseForNameQueryString(nameQueryString, "John", null, "Smith", queryBuilderJson, 2);
 
@@ -180,15 +183,15 @@ public class NameSearchQueryBuilderTest {
             assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[4].bool.must[" + additionalPartyFilterSize + "].match['parties.firstName.ngrammed'].query", equalTo(firstName)));
 
             if (middleName == null && lastName == null) {
-                assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[4].bool.must[" + additionalPartyFilterSize + "].match['parties.firstName.ngrammed'].boost", equalTo(1.7)));
+                assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[4].bool.must[" + additionalPartyFilterSize + "].match['parties.firstName.ngrammed'].boost", is(closeTo(1.7f, 0.0001f))));
 
 
-                    assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[4].bool.must[" + additionalPartyFilterSize + "].match['parties.aliases.firstName.ngrammed'].boost", equalTo(1.7)));
+                    assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[4].bool.must[" + additionalPartyFilterSize + "].match['parties.aliases.firstName.ngrammed'].boost", is(closeTo(1.7f, 0.0001f))));;
 
             } else {
-                assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[4].bool.must[" + additionalPartyFilterSize + "].match['parties.firstName.ngrammed'].boost", equalTo(1.7)));
+                assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[4].bool.must[" + additionalPartyFilterSize + "].match['parties.firstName.ngrammed'].boost", is(closeTo(1.7f, 0.0001f))));
 
-                    assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[4].bool.must[" + additionalPartyFilterSize + "].match['parties.aliases.firstName.ngrammed'].boost", equalTo(1.7)));
+                    assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[4].bool.must[" + additionalPartyFilterSize + "].match['parties.aliases.firstName.ngrammed'].boost", is(closeTo(1.7f, 0.0001f))));
 
             }
 
@@ -245,33 +248,33 @@ public class NameSearchQueryBuilderTest {
         assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[1].bool.boost", equalTo(2.0)));
 
         assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.query", equalTo(fullName)));
-        assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.operator", equalTo("AND")));
+        assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.operator", equalTo("and")));
         assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.type", equalTo("cross_fields")));
         assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.fields", hasSize(4)));
 
         if (middleName == null && lastName == null) {
             assertThat(queryBuilderJson,
                     hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.fields",
-                            containsInAnyOrder("parties.firstName^1.0", "parties.lastName^2.0", "parties.middleName^1.0", "parties.organisationName^2.0")));
+                            containsInAnyOrder("parties.firstName", "parties.lastName^2.0f", "parties.middleName", "parties.organisationName^2.0f")));
         } else {
             assertThat(queryBuilderJson,
                     hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.fields",
-                            containsInAnyOrder("parties.firstName^1.0", "parties.lastName^1.0", "parties.middleName^1.0", "parties.organisationName^1.0")));
+                            containsInAnyOrder("parties.firstName", "parties.lastName", "parties.middleName", "parties.organisationName")));
         }
 
         assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.query", equalTo(fullName)));
-        assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.operator", equalTo("OR")));
+        assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.operator", equalTo("or")));
         assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.type", equalTo("cross_fields")));
         assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.fields", hasSize(4)));
 
         if (middleName == null && lastName == null) {
             assertThat(queryBuilderJson,
                     hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.fields",
-                            containsInAnyOrder("parties.firstName^1.0", "parties.lastName^2.0", "parties.middleName^1.0", "parties.organisationName^2.0")));
+                            containsInAnyOrder("parties.firstName", "parties.lastName^2.0f", "parties.middleName", "parties.organisationName^2.0f")));
         } else {
             assertThat(queryBuilderJson,
                     hasJsonPath("$.dis_max.queries[0].nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.fields",
-                            containsInAnyOrder("parties.firstName^1.0", "parties.lastName^1.0", "parties.middleName^1.0", "parties.organisationName^1.0")));
+                            containsInAnyOrder("parties.firstName", "parties.lastName", "parties.middleName", "parties.organisationName")));
         }
 
 
@@ -284,33 +287,33 @@ public class NameSearchQueryBuilderTest {
 
 
             assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.query", equalTo(fullName)));
-            assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.operator", equalTo("AND")));
+            assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.operator", equalTo("and")));
             assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.type", equalTo("cross_fields")));
             assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.fields", hasSize(4)));
 
             if (middleName == null && lastName == null) {
                 assertThat(queryBuilderJson,
                         hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.fields",
-                                containsInAnyOrder("parties.aliases.firstName^1.0", "parties.aliases.lastName^2.0", "parties.aliases.middleName^1.0", "parties.aliases.organisationName^2.0")));
+                                containsInAnyOrder("parties.aliases.firstName", "parties.aliases.lastName^2.0f", "parties.aliases.middleName", "parties.aliases.organisationName^2.0f")));
             } else {
                 assertThat(queryBuilderJson,
                         hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[2].bool.must[" + additionalPartyFilterSize + "].multi_match.fields",
-                                containsInAnyOrder("parties.aliases.firstName^1.0", "parties.aliases.lastName^1.0", "parties.aliases.middleName^1.0", "parties.aliases.organisationName^1.0")));
+                                containsInAnyOrder("parties.aliases.firstName", "parties.aliases.lastName", "parties.aliases.middleName", "parties.aliases.organisationName")));
             }
 
             assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.query", equalTo(fullName)));
-            assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.operator", equalTo("OR")));
+            assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.operator", equalTo("or")));
             assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.type", equalTo("cross_fields")));
             assertThat(queryBuilderJson, hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.fields", hasSize(4)));
 
             if (middleName == null && lastName == null) {
                 assertThat(queryBuilderJson,
                         hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.fields",
-                                containsInAnyOrder("parties.aliases.firstName^1.0", "parties.aliases.lastName^2.0", "parties.aliases.middleName^1.0", "parties.aliases.organisationName^2.0")));
+                                containsInAnyOrder("parties.aliases.firstName", "parties.aliases.lastName^2.0f", "parties.aliases.middleName", "parties.aliases.organisationName^2.0f")));
             } else {
                 assertThat(queryBuilderJson,
                         hasJsonPath("$.dis_max.queries[1].nested.query.nested.query.bool.should[3].bool.must[" + additionalPartyFilterSize + "].multi_match.fields",
-                                containsInAnyOrder("parties.aliases.firstName^1.0", "parties.aliases.lastName^1.0", "parties.aliases.middleName^1.0", "parties.aliases.organisationName^1.0")));
+                                containsInAnyOrder("parties.aliases.firstName", "parties.aliases.lastName", "parties.aliases.middleName", "parties.aliases.organisationName")));
             }
 
 

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NinoSearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/NinoSearchQueryBuilderTest.java
@@ -1,13 +1,13 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.PARTIES_NINO_REFERENCE_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,15 +24,13 @@ public class NinoSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForHearingDateFrom() {
         final String nino = "AB123456Z";
 
-        final QueryBuilder actualQueryBuilder = ninoSearchQueryBuilder.getQueryBuilderBy(nino);
+        final Query actualQuery = ninoSearchQueryBuilder.getQueryBuilderBy(nino);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
+        assertThat(actualQuery, is(notNullValue()));
+        final TermQuery termQueryBuilder = actualQuery.term();
+        assertThat(actualQuery, notNullValue());
 
-        assertThat(actualQueryBuilder, instanceOf(TermQueryBuilder.class));
-
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) actualQueryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(PARTIES_NINO_REFERENCE_PATH));
-        assertThat(termQueryBuilder.value(), is(nino));
+        assertThat(termQueryBuilder.field(), is(PARTIES_NINO_REFERENCE_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(nino));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PartyTypeSearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PartyTypeSearchQueryBuilderTest.java
@@ -2,15 +2,15 @@ package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
 import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 import java.util.List;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermsQueryBuilder;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,16 +27,15 @@ public class PartyTypeSearchQueryBuilderTest {
     @Test
     public void shouldGetQueryBuilderBy() {
 
-        final QueryBuilder actualQueryBuilder = partyTypeSearchQueryBuilder.getQueryBuilderBy(" APPLICANT  , DEFENDANT  ");
+        final Query actualQuery = partyTypeSearchQueryBuilder.getQueryBuilderBy(" APPLICANT  , DEFENDANT  ");
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
+        assertThat(actualQuery, is(notNullValue()));
+        final TermsQuery actualTermsQuery = actualQuery.terms();
+        assertThat(actualTermsQuery, notNullValue());
 
-        assertThat(actualQueryBuilder, instanceOf(TermsQueryBuilder.class));
 
-        final TermsQueryBuilder actualTermsQuery = (TermsQueryBuilder) actualQueryBuilder;
-
-        assertThat(actualTermsQuery.fieldName(), is("parties._party_type"));
-        final List<Object> queryValues = actualTermsQuery.values();
+        assertThat(actualTermsQuery.field(), is("parties._party_type"));
+        final List<String> queryValues = actualTermsQuery.terms().value().stream().map(FieldValue::stringValue).toList();
 
         assertThat(queryValues, hasSize(2));
         assertThat(queryValues, hasItems("APPLICANT", "DEFENDANT"));

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PncIdQueryBuilderTest.java
@@ -1,13 +1,12 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.PNC_ID_INDEX;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.Test;
 
 public class PncIdQueryBuilderTest {
@@ -18,15 +17,13 @@ public class PncIdQueryBuilderTest {
     public void shouldCreateExactMatchQueryBuilderForPncIdNumber() {
 
         final String pncId = "123456";
-        final QueryBuilder queryBuilder = pncIdQueryBuilder.getQueryBuilderBy(pncId);
+        final Query query = pncIdQueryBuilder.getQueryBuilderBy(pncId);
 
-        assertThat(queryBuilder, is(notNullValue()));
+        assertThat(query, is(notNullValue()));
+        final TermQuery termQueryBuilder = query.term();
+        assertThat(termQueryBuilder, notNullValue());
 
-        assertThat(queryBuilder, instanceOf(TermQueryBuilder.class));
-
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) queryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(PNC_ID_INDEX));
-        assertThat(termQueryBuilder.value(), is("123456"));
+        assertThat(termQueryBuilder.field(), is(PNC_ID_INDEX));
+        assertThat(termQueryBuilder.value().stringValue(), is("123456"));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PostCodeQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/PostCodeQueryBuilderTest.java
@@ -1,12 +1,11 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import org.junit.jupiter.api.Test;
 
 public class PostCodeQueryBuilderTest {
@@ -17,15 +16,14 @@ public class PostCodeQueryBuilderTest {
         final PostCodeQueryBuilder postCodeQueryBuilder = new PostCodeQueryBuilder();
 
         final String postCode = "W13 7TB";
-        final QueryBuilder actualQueryBuilder = postCodeQueryBuilder.getQueryBuilderBy(postCode);
+        final Query actualQuery = postCodeQueryBuilder.getQueryBuilderBy(postCode);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(MatchQueryBuilder.class));
+        assertThat(actualQuery, is(notNullValue()));
+        final MatchQuery matchQueryBuilder = actualQuery.match();
+        assertThat(matchQueryBuilder, notNullValue());
 
-        final MatchQueryBuilder matchQueryBuilder = (MatchQueryBuilder) actualQueryBuilder;
-        assertThat(matchQueryBuilder.getName(), is("match"));
-        assertThat(matchQueryBuilder.fieldName(), is("parties.postCode"));
-        assertThat(matchQueryBuilder.value(), is(postCode));
+        assertThat(matchQueryBuilder.field(), is("parties.postCode"));
+        assertThat(matchQueryBuilder.query().stringValue(), is(postCode));
     }
 
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ProceedingsConcludedQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ProceedingsConcludedQueryBuilderTest.java
@@ -7,10 +7,10 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.DefendantQueryParameterNamesConstants.PROCEEDINGS_CONCLUDED_INDEX;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.ExistsQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ExistsQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import org.junit.jupiter.api.Test;
 
 public class ProceedingsConcludedQueryBuilderTest {
@@ -21,57 +21,45 @@ public class ProceedingsConcludedQueryBuilderTest {
     @Test
     public void shouldCreateQueryBuilderWhenTrue() {
 
-        final String proceedingsConcluded = "true";
-        final QueryBuilder queryBuilder = proceedingsConcludedQueryBuilder.getQueryBuilderBy(proceedingsConcluded);
+        final Query query = proceedingsConcludedQueryBuilder.getQueryBuilderBy(true);
 
-        assertThat(queryBuilder, is(notNullValue()));
-        assertThat(queryBuilder, instanceOf(BoolQueryBuilder.class));
+        assertThat(query, is(notNullValue()));
 
-        final BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) queryBuilder;
-        assertThat(boolQueryBuilder.getName(), is("bool"));
+        final BoolQuery boolQueryBuilder =  query.bool();
         assertThat(boolQueryBuilder.should(), hasSize(0));
         assertThat(boolQueryBuilder.must(), hasSize(1));
         assertThat(boolQueryBuilder.mustNot(), hasSize(0));
 
-        final QueryBuilder firstMustClause = boolQueryBuilder.must().get(0);
-        assertThat(firstMustClause, instanceOf(TermQueryBuilder.class));
+        final Query firstMustClause = boolQueryBuilder.must().get(0);
 
-        final TermQueryBuilder firstTerm = (TermQueryBuilder) firstMustClause;
-        assertThat(firstTerm.getName(), is("term"));
-        assertThat(firstTerm.fieldName(), is(PROCEEDINGS_CONCLUDED_INDEX));
-        assertThat(firstTerm.value(), is("true"));
+        final TermQuery firstTerm = firstMustClause.term();
+        assertThat(firstTerm.field(), is(PROCEEDINGS_CONCLUDED_INDEX));
+        assertThat(firstTerm.value().booleanValue(), is(true));
     }
 
 
     @Test
     public void shouldCreateQueryBuilderWhenFalse() {
 
-        final String proceedingsConcluded = "false";
-        final QueryBuilder queryBuilder = proceedingsConcludedQueryBuilder.getQueryBuilderBy(proceedingsConcluded);
+        final Query query = proceedingsConcludedQueryBuilder.getQueryBuilderBy(false);
 
-        assertThat(queryBuilder, is(notNullValue()));
-        assertThat(queryBuilder, instanceOf((BoolQueryBuilder.class)));
+        assertThat(query, is(notNullValue()));
 
-        final BoolQueryBuilder actualBoolQueryBuilder = (BoolQueryBuilder) queryBuilder;
-        assertThat(actualBoolQueryBuilder.getName(), is("bool"));
+        final BoolQuery actualBoolQueryBuilder = query.bool();
         assertThat(actualBoolQueryBuilder.should(), hasSize(2));
         assertThat(actualBoolQueryBuilder.must(), hasSize(0));
         assertThat(actualBoolQueryBuilder.mustNot(), hasSize(0));
 
-        final QueryBuilder firstShouldClause = actualBoolQueryBuilder.should().get(0);
-        final QueryBuilder secondShouldClause = actualBoolQueryBuilder.should().get(1);
+        final Query firstShouldClause = actualBoolQueryBuilder.should().get(0);
+        final Query secondShouldClause = actualBoolQueryBuilder.should().get(1);
 
-        assertThat(firstShouldClause, instanceOf(TermQueryBuilder.class));
-        assertThat(secondShouldClause, instanceOf(BoolQueryBuilder.class));
+        final TermQuery firstTerm = firstShouldClause.term();
+        assertThat(firstTerm.field(), is(PROCEEDINGS_CONCLUDED_INDEX));
+        assertThat(firstTerm.value().booleanValue(), is(false));
 
-        final TermQueryBuilder firstTerm = (TermQueryBuilder) firstShouldClause;
-        assertThat(firstTerm.getName(), is("term"));
-        assertThat(firstTerm.fieldName(), is(PROCEEDINGS_CONCLUDED_INDEX));
-        assertThat(firstTerm.value(), is("false"));
-
-        final BoolQueryBuilder secondBoolQueryBuilder = (BoolQueryBuilder) secondShouldClause;
+        final BoolQuery secondBoolQueryBuilder = secondShouldClause.bool();
         assertThat(secondBoolQueryBuilder.mustNot().size(), is(1));
-        ExistsQueryBuilder existsQueryBuilder = (ExistsQueryBuilder) secondBoolQueryBuilder.mustNot().get(0);
-        assertThat(existsQueryBuilder.fieldName(), is(PROCEEDINGS_CONCLUDED_INDEX));
+        ExistsQuery existsQueryBuilder = secondBoolQueryBuilder.mustNot().get(0).exists();
+        assertThat(existsQueryBuilder.field(), is(PROCEEDINGS_CONCLUDED_INDEX));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ProsecutingAuthoritySearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ProsecutingAuthoritySearchQueryBuilderTest.java
@@ -1,14 +1,13 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
 import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,25 +23,20 @@ public class ProsecutingAuthoritySearchQueryBuilderTest {
     @Test
     public void shouldReturnValidQueryBuilderForProsecutingAuthority() {
         final String prosecutingAuthority = "tfl";
-        final QueryBuilder actualQueryBuilder = prosecutingAuthoritySearchQueryBuilder.getQueryBuilderBy(prosecutingAuthority);
+        final Query actualQuery = prosecutingAuthoritySearchQueryBuilder.getQueryBuilderBy(prosecutingAuthority);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf((BoolQueryBuilder.class)));
+        assertThat(actualQuery, is(notNullValue()));
 
-        final BoolQueryBuilder actualBoolQueryBuilder = (BoolQueryBuilder) actualQueryBuilder;
-        assertThat(actualBoolQueryBuilder.getName(), is("bool"));
+        final BoolQuery actualBoolQueryBuilder = actualQuery.bool();
         assertThat(actualBoolQueryBuilder.must(), hasSize(0));
         assertThat(actualBoolQueryBuilder.should(), hasSize(0));
 
         assertThat(actualBoolQueryBuilder.filter(), hasSize(1));
 
-        final QueryBuilder firstFilter = actualBoolQueryBuilder.filter().get(0);
+        final Query firstFilter = actualBoolQueryBuilder.filter().get(0);
 
-        assertThat(firstFilter, instanceOf(TermQueryBuilder.class));
-
-        final TermQueryBuilder firstTerm = (TermQueryBuilder) firstFilter;
-        assertThat(firstTerm.getName(), is("term"));
-        assertThat(firstTerm.fieldName(), is("prosecutingAuthority"));
-        assertThat(firstTerm.value(), is(prosecutingAuthority));
+        final TermQuery firstTerm = firstFilter.term();
+        assertThat(firstTerm.field(), is("prosecutingAuthority"));
+        assertThat(firstTerm.value().stringValue(), is(prosecutingAuthority));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ReferenceSearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/ReferenceSearchQueryBuilderTest.java
@@ -3,17 +3,18 @@ package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 import static com.google.common.collect.ImmutableList.of;
 import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
 import static java.util.Collections.emptyList;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.apache.lucene.search.join.ScoreMode;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.NestedQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
 import org.junit.jupiter.api.Test;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import co.elastic.clients.elasticsearch.core.search.ScoreMode;
 
 public class ReferenceSearchQueryBuilderTest {
 
@@ -24,91 +25,86 @@ public class ReferenceSearchQueryBuilderTest {
     @Test
     public void shouldReturnValidQueryBuilderReference() {
         final String caseReference = "TFF123";
-        final QueryBuilder actualQueryBuilder = referenceSearchQueryBuilder.getQueryBuilderBy(caseReference, emptyList());
+        final Query actualQuery = referenceSearchQueryBuilder.getQueryBuilderBy(caseReference, emptyList());
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf((BoolQueryBuilder.class)));
+        assertThat(actualQuery, is(notNullValue()));
+        final BoolQuery actualBoolQueryBuilder = actualQuery.bool();
+        assertThat(actualBoolQueryBuilder, notNullValue());
 
-        final BoolQueryBuilder actualBoolQueryBuilder = (BoolQueryBuilder) actualQueryBuilder;
-        assertThat(actualBoolQueryBuilder.getName(), is("bool"));
+
         assertThat(actualBoolQueryBuilder.must(), hasSize(0));
         assertThat(actualBoolQueryBuilder.should(), hasSize(2));
 
         assertThat(actualBoolQueryBuilder.filter(), hasSize(0));
 
-        final QueryBuilder firstShould = actualBoolQueryBuilder.should().get(0);
+        final Query firstShould = actualBoolQueryBuilder.should().get(0);
 
-        assertThat(firstShould, instanceOf(TermQueryBuilder.class));
+        assertThat(firstShould.term(), notNullValue());
 
-        final TermQueryBuilder firstTermShould = (TermQueryBuilder) firstShould;
-        assertThat(firstTermShould.getName(), is("term"));
-        assertThat(firstTermShould.fieldName(), is("caseReference"));
-        assertThat(firstTermShould.value(), is(caseReference));
+        final TermQuery firstTermShould = firstShould.term();
+        assertThat(firstTermShould.field(), is("caseReference"));
+        assertThat(firstTermShould.value().stringValue(), is(caseReference));
 
-        final QueryBuilder secondShould = actualBoolQueryBuilder.should().get(1);
-        assertThat(secondShould, instanceOf(NestedQueryBuilder.class));
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) secondShould;
-        assertThat(actualNestedQueryBuilder.scoreMode(), is(ScoreMode.Avg));
+        final Query secondShould = actualBoolQueryBuilder.should().get(1);
+        assertThat(secondShould.nested(), notNullValue());
+        final NestedQuery actualNestedQueryBuilder = secondShould.nested();
+        assertThat(actualNestedQueryBuilder.scoreMode().name(), is(ScoreMode.Avg.name()));
 
-        final BoolQueryBuilder innedBoolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        final BoolQuery innedBoolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(innedBoolQueryBuilder.mustNot(), hasSize(0));
         assertThat(innedBoolQueryBuilder.should(), hasSize(0));
         assertThat(innedBoolQueryBuilder.must(), hasSize(1));
-        final QueryBuilder firstMust = innedBoolQueryBuilder.must().get(0);
-        assertThat(firstMust, instanceOf(TermQueryBuilder.class));
-        final TermQueryBuilder actualNestedTermQueryBuilder = (TermQueryBuilder) firstMust;
-        assertThat(actualNestedTermQueryBuilder.getName(), is("term"));
-        assertThat(actualNestedTermQueryBuilder.fieldName(), is("applications.applicationReference"));
-        assertThat(actualNestedTermQueryBuilder.value(), is(caseReference));
+        final Query firstMust = innedBoolQueryBuilder.must().get(0);
+        assertThat(firstMust.term(), notNullValue());
+        final TermQuery actualNestedTermQueryBuilder = firstMust.term();
+        assertThat(actualNestedTermQueryBuilder.field(), is("applications.applicationReference"));
+        assertThat(actualNestedTermQueryBuilder.value().stringValue(), is(caseReference));
 
     }
 
     @Test
     public void shouldReturnValidQueryBuilderReferenceWithApplicationType() {
         final String caseReference = "TFF123";
-        final QueryBuilder applicationTypeQueryBuilder = new ApplicationTypeQueryBuilder().getQueryBuilderBy("Some Application Type");
+        final Query applicationTypeQuery = new ApplicationTypeQueryBuilder().getQueryBuilderBy("Some Application Type");
 
-        final QueryBuilder actualQueryBuilder = referenceSearchQueryBuilder.getQueryBuilderBy(caseReference, of(applicationTypeQueryBuilder));
+        final Query actualQuery = referenceSearchQueryBuilder.getQueryBuilderBy(caseReference, of(applicationTypeQuery));
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf((BoolQueryBuilder.class)));
+        assertThat(actualQuery, is(notNullValue()));
+        assertThat(actualQuery.bool(), notNullValue());
 
-        final BoolQueryBuilder actualBoolQueryBuilder = (BoolQueryBuilder) actualQueryBuilder;
-        assertThat(actualBoolQueryBuilder.getName(), is("bool"));
+        final BoolQuery actualBoolQueryBuilder = actualQuery.bool();
         assertThat(actualBoolQueryBuilder.must(), hasSize(0));
         assertThat(actualBoolQueryBuilder.should(), hasSize(2));
 
         assertThat(actualBoolQueryBuilder.filter(), hasSize(0));
 
-        final QueryBuilder firstShould = actualBoolQueryBuilder.should().get(0);
+        final Query firstShould = actualBoolQueryBuilder.should().get(0);
 
-        assertThat(firstShould, instanceOf(TermQueryBuilder.class));
+        assertThat(firstShould.term(), notNullValue());
 
-        final TermQueryBuilder firstTermShould = (TermQueryBuilder) firstShould;
-        assertThat(firstTermShould.getName(), is("term"));
-        assertThat(firstTermShould.fieldName(), is("caseReference"));
-        assertThat(firstTermShould.value(), is(caseReference));
+        final TermQuery firstTermShould = firstShould.term();
+        assertThat(firstTermShould.field(), is("caseReference"));
+        assertThat(firstTermShould.value().stringValue(), is(caseReference));
 
-        final QueryBuilder secondShould = actualBoolQueryBuilder.should().get(1);
-        assertThat(secondShould, instanceOf(NestedQueryBuilder.class));
-        final NestedQueryBuilder actualNestedQueryBuilder = (NestedQueryBuilder) secondShould;
-        assertThat(actualNestedQueryBuilder.scoreMode(), is(ScoreMode.Avg));
+        final Query secondShould = actualBoolQueryBuilder.should().get(1);
+        assertThat(secondShould.nested(), notNullValue());
+        final NestedQuery actualNestedQueryBuilder = secondShould.nested();
+        assertThat(actualNestedQueryBuilder.scoreMode(), is(ChildScoreMode.Avg));
 
-        final BoolQueryBuilder innedBoolQueryBuilder = (BoolQueryBuilder) actualNestedQueryBuilder.query();
+        final BoolQuery innedBoolQueryBuilder = actualNestedQueryBuilder.query().bool();
         assertThat(innedBoolQueryBuilder.mustNot(), hasSize(0));
         assertThat(innedBoolQueryBuilder.should(), hasSize(0));
         assertThat(innedBoolQueryBuilder.must(), hasSize(2));
 
-        final QueryBuilder firstMust = innedBoolQueryBuilder.must().get(0);
-        assertThat(firstMust, instanceOf(TermQueryBuilder.class));
-        final TermQueryBuilder actualNestedTermQueryBuilder = (TermQueryBuilder) firstMust;
-        assertThat(actualNestedTermQueryBuilder.getName(), is("term"));
-        assertThat(actualNestedTermQueryBuilder.fieldName(), is("applications.applicationReference"));
-        assertThat(actualNestedTermQueryBuilder.value(), is(caseReference));
+        final Query firstMust = innedBoolQueryBuilder.must().get(0);
+        assertThat(firstMust.term(), notNullValue());
+        final TermQuery actualNestedTermQueryBuilder = firstMust.term();
+        assertThat(actualNestedTermQueryBuilder.field(), is("applications.applicationReference"));
+        assertThat(actualNestedTermQueryBuilder.value().stringValue(), is(caseReference));
 
-        final QueryBuilder secondMust = innedBoolQueryBuilder.must().get(1);
+        final Query secondMust = innedBoolQueryBuilder.must().get(1);
 
-        assertThat(secondMust, is(applicationTypeQueryBuilder));
+        assertThat(secondMust, is(applicationTypeQuery));
 
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/VirualBoxHearingQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/VirualBoxHearingQueryBuilderTest.java
@@ -1,14 +1,14 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CaseSearchConstants.IS_VIRTUAL_BOX_HEARING_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
 import org.junit.jupiter.api.Test;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 
 public class VirualBoxHearingQueryBuilderTest {
     private VirtualBoxHearingQueryBuilder virtualBoxHearingQueryBuilder = new VirtualBoxHearingQueryBuilder();
@@ -17,16 +17,15 @@ public class VirualBoxHearingQueryBuilderTest {
     public void shouldCreateQueryBuilder() {
 
         final String isVirtualBoxHearing = "true";
-        final QueryBuilder queryBuilder = virtualBoxHearingQueryBuilder.getQueryBuilderBy(isVirtualBoxHearing);
+        final Query query = virtualBoxHearingQueryBuilder.getQueryBuilderBy(isVirtualBoxHearing);
 
-        assertThat(queryBuilder, is(notNullValue()));
+        assertThat(query, is(notNullValue()));
 
-        assertThat(queryBuilder, instanceOf(TermQueryBuilder.class));
+        assertThat(query.term(), notNullValue());
 
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) queryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(IS_VIRTUAL_BOX_HEARING_PATH));
-        assertThat(termQueryBuilder.value(), is(true));
+        final TermQuery termQueryBuilder =  query.term();
+        assertThat(termQueryBuilder.field(), is(IS_VIRTUAL_BOX_HEARING_PATH));
+        assertThat(termQueryBuilder.value().booleanValue(), is(true));
     }
 
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CourtHouseQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/CourtHouseQueryBuilderTest.java
@@ -1,15 +1,15 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.COURT_HOUSE_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 
 public class CourtHouseQueryBuilderTest {
 
@@ -23,15 +23,14 @@ public class CourtHouseQueryBuilderTest {
     @Test
     public void shouldReturnValidQueryBuilderForHearingDateTo() {
         final String courtHouse = "C43OX00";
-        final QueryBuilder actualQueryBuilder = courtHouseQueryBuilder.getQueryBuilderBy(courtHouse);
+        final Query actualQuery = courtHouseQueryBuilder.getQueryBuilderBy(courtHouse);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(TermQueryBuilder.class));
+        assertThat(actualQuery, is(notNullValue()));
+        assertThat(actualQuery.term(), notNullValue());
 
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) actualQueryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(COURT_HOUSE_PATH));
-        assertThat(termQueryBuilder.value(), is(courtHouse));
+        final TermQuery termQueryBuilder = actualQuery.term();
+        assertThat(termQueryBuilder.field(), is(COURT_HOUSE_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(courtHouse));
     }
 }
 

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/HearingDateTimeQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/HearingDateTimeQueryBuilderTest.java
@@ -1,17 +1,19 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.builders.utils.HearingDateUtil.stringToDate;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.HEARING_DATE_TIME_PATH;
 
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.RangeQueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
+import java.time.LocalDate;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.UntypedRangeQuery;
 
 public class HearingDateTimeQueryBuilderTest {
 
@@ -26,31 +28,26 @@ public class HearingDateTimeQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForHearingDateFrom() {
         final String hearingDateFrom = "2021-04-19";
         final String hearingDateTo = "";
-        final QueryBuilder actualQueryBuilder = hearingDateTimeQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
+        final Query actualQuery = hearingDateTimeQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
+        assertThat(actualQuery, is(notNullValue()));
 
-        assertThat(actualQueryBuilder, instanceOf(TermQueryBuilder.class));
-
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) actualQueryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(HEARING_DATE_TIME_PATH));
-        assertThat(termQueryBuilder.value(), is(hearingDateFrom));
+        final TermQuery termQueryBuilder = actualQuery.term();
+        assertThat(termQueryBuilder.field(), is(HEARING_DATE_TIME_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(hearingDateFrom));
     }
 
     @Test
     public void shouldReturnValidQueryBuilderForHearingDateTo() {
         final String hearingDateFrom = "";
         final String hearingDateTo = "2021-04-19";
-        final QueryBuilder actualQueryBuilder = hearingDateTimeQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
+        final Query actualQuery = hearingDateTimeQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(TermQueryBuilder.class));
+        assertThat(actualQuery, is(notNullValue()));
 
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) actualQueryBuilder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(HEARING_DATE_TIME_PATH));
-        assertThat(termQueryBuilder.value(), is(hearingDateTo));
+        final TermQuery termQueryBuilder = actualQuery.term();
+        assertThat(termQueryBuilder.field(), is(HEARING_DATE_TIME_PATH));
+        assertThat(termQueryBuilder.value().stringValue(), is(hearingDateTo));
     }
 
     @Test
@@ -58,16 +55,14 @@ public class HearingDateTimeQueryBuilderTest {
         final String hearingDateFrom = "2021-04-19";
         final String hearingDateTo = "2021-05-17";
 
-        final QueryBuilder actualQueryBuilder = hearingDateTimeQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
+        final Query actualQuery = hearingDateTimeQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf(RangeQueryBuilder.class));
+        assertThat(actualQuery, is(notNullValue()));
 
-        final RangeQueryBuilder rangeQueryBuilder = (RangeQueryBuilder) actualQueryBuilder;
-        assertThat(rangeQueryBuilder.getName(), is("range"));
-        assertThat(rangeQueryBuilder.fieldName(), is(HEARING_DATE_TIME_PATH));
-        assertThat(rangeQueryBuilder.from(), is(stringToDate(hearingDateFrom)));
-        assertThat(rangeQueryBuilder.to(), is(stringToDate(hearingDateTo)));
+        final UntypedRangeQuery rangeQueryBuilder = actualQuery.range().untyped();
+        assertThat(rangeQueryBuilder.field(), is(HEARING_DATE_TIME_PATH));
+        assertThat(rangeQueryBuilder.gte().to(LocalDate.class), is(stringToDate(hearingDateFrom)));
+        assertThat(rangeQueryBuilder.lte().to(LocalDate.class), is(stringToDate(hearingDateTo)));
     }
 }
 

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/OperationNameQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/OperationNameQueryBuilderTest.java
@@ -1,18 +1,17 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
-
 import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.OPERATION_NAME;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.OPERATION_NAME_PATH_NGRAMMED;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.junit.jupiter.api.Test;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public class OperationNameQueryBuilderTest {
 
@@ -21,29 +20,27 @@ public class OperationNameQueryBuilderTest {
     @Test
     public void shouldReturnOperationNameQueryBuilder() {
         final String operationName = "Shield Service";
-        final QueryBuilder queryBuilder = operationNameQueryBuilder.getQueryBuilderBy(operationName);
+        final Query query = operationNameQueryBuilder.getQueryBuilderBy(operationName);
 
-        assertThat(queryBuilder, notNullValue());
-        assertThat(queryBuilder, instanceOf(BoolQueryBuilder.class));
+        assertThat(query, notNullValue());
+        assertThat(query.bool(), notNullValue());
 
-        final BoolQueryBuilder booleanQueryBuilder = (BoolQueryBuilder) queryBuilder;
+        final BoolQuery booleanQueryBuilder = query.bool();
         assertThat(booleanQueryBuilder.must(), hasSize(0));
         assertThat(booleanQueryBuilder.should(), hasSize(2));
 
-        final QueryBuilder operationShould = booleanQueryBuilder.should().get(0);
-        final QueryBuilder operationNgrammedShoud = booleanQueryBuilder.should().get(1);
-        assertThat(operationShould, instanceOf(MatchQueryBuilder.class));
-        assertThat(operationNgrammedShoud, instanceOf(MatchQueryBuilder.class));
+        final Query operationShould = booleanQueryBuilder.should().get(0);
+        final Query operationNgrammedShoud = booleanQueryBuilder.should().get(1);
+        assertThat(operationShould.match(), notNullValue());
+        assertThat(operationNgrammedShoud.match(), notNullValue());
 
-        final MatchQueryBuilder operationQueryBuilder = (MatchQueryBuilder) operationShould;
-        assertThat(operationQueryBuilder.getName(), is("match"));
-        assertThat(operationQueryBuilder.value(), is(operationName));
-        assertThat(operationQueryBuilder.fieldName(), is(OPERATION_NAME));
+        final MatchQuery operationQueryBuilder = operationShould.match();
+        assertThat(operationQueryBuilder.query().stringValue(), is(operationName));
+        assertThat(operationQueryBuilder.field(), is(OPERATION_NAME));
 
-        final MatchQueryBuilder operationNgramQueryBuilder = (MatchQueryBuilder) operationNgrammedShoud;
-        assertThat(operationNgramQueryBuilder.getName(), is("match"));
-        assertThat(operationNgramQueryBuilder.value(), is(operationName));
-        assertThat(operationNgramQueryBuilder.fieldName(), is(OPERATION_NAME_PATH_NGRAMMED));
+        final MatchQuery operationNgramQueryBuilder = operationNgrammedShoud.match();
+        assertThat(operationNgramQueryBuilder.query().stringValue(), is(operationName));
+        assertThat(operationNgramQueryBuilder.field(), is(OPERATION_NAME_PATH_NGRAMMED));
     }
 
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/UrnSearchQueryBuilderTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/elasticsearch/builders/cps/UrnSearchQueryBuilderTest.java
@@ -1,17 +1,17 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps;
 
 import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.URN;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 
 public class UrnSearchQueryBuilderTest {
 
@@ -26,21 +26,19 @@ public class UrnSearchQueryBuilderTest {
     public void shouldReturnValidQueryBuilderForCourtQueryBuilder() {
         final String urn = "3fdcf368";
 
-        final QueryBuilder actualQueryBuilder = urnSearchQueryBuilder.getQueryBuilderBy(urn);
+        final Query actualQuery = urnSearchQueryBuilder.getQueryBuilderBy(urn);
 
-        assertThat(actualQueryBuilder, is(notNullValue()));
-        assertThat(actualQueryBuilder, instanceOf((BoolQueryBuilder.class)));
-        final BoolQueryBuilder actualBoolQueryBuilder = (BoolQueryBuilder) actualQueryBuilder;
-        assertThat(actualBoolQueryBuilder.getName(), is("bool"));
+        assertThat(actualQuery, is(notNullValue()));
+        assertThat(actualQuery.bool(), notNullValue());
+        final BoolQuery actualBoolQueryBuilder = actualQuery.bool();
 
         assertThat(actualBoolQueryBuilder.must(), hasSize(0));
 
-        final QueryBuilder builder = actualBoolQueryBuilder.filter().get(0);
-        assertThat(builder, instanceOf(TermQueryBuilder.class));
+        final Query builder = actualBoolQueryBuilder.filter().get(0);
+        assertThat(builder.term(), notNullValue());
 
-        final TermQueryBuilder termQueryBuilder = (TermQueryBuilder) builder;
-        assertThat(termQueryBuilder.getName(), is("term"));
-        assertThat(termQueryBuilder.fieldName(), is(URN));
-        assertThat(termQueryBuilder.value(), is(urn));
+        final TermQuery termQueryBuilder = builder.term();
+        assertThat(termQueryBuilder.field(), is(URN));
+        assertThat(termQueryBuilder.value().stringValue(), is(urn));
     }
 }

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/AbstractQueryBuilderServiceTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/AbstractQueryBuilderServiceTest.java
@@ -1,36 +1,35 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.service;
 
 import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
-import static org.apache.lucene.search.join.ScoreMode.Avg;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 import java.util.List;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.NestedQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public abstract class AbstractQueryBuilderServiceTest {
 
-    protected void checkNestedFilter(final QueryBuilder resultQueryBuilder) {
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        final BoolQueryBuilder resultQueryBuilderAsBool = (BoolQueryBuilder) resultQueryBuilder;
+    protected void checkNestedFilter(final Query resultQuery) {
+
+        final BoolQuery resultQueryBuilderAsBool = resultQuery.bool();
         assertThat(resultQueryBuilderAsBool.filter(), hasSize(0));
         assertThat(resultQueryBuilderAsBool.should(), hasSize(0));
         assertThat(resultQueryBuilderAsBool.mustNot(), hasSize(0));
-        final List<QueryBuilder> must = resultQueryBuilderAsBool.must();
+        final List<Query> must = resultQueryBuilderAsBool.must();
         assertThat(must, hasSize(1));
 
-        final QueryBuilder firstMust = resultQueryBuilderAsBool.must().get(0);
-        assertThat(firstMust, instanceOf(NestedQueryBuilder.class));
-        final NestedQueryBuilder nestedQueryBuilder = (NestedQueryBuilder) firstMust;
-        assertThat(nestedQueryBuilder.getName(), is("nested"));
-        assertThat(nestedQueryBuilder.scoreMode(), is(Avg));
-        final QueryBuilder innerQueryBuilder = nestedQueryBuilder.query();
-        assertThat(innerQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        final BoolQueryBuilder innerBoolQueryBuilder = (BoolQueryBuilder) innerQueryBuilder;
+        final Query firstMust = resultQueryBuilderAsBool.must().get(0);
+        assertThat(firstMust.nested(), notNullValue());
+        final NestedQuery nestedQueryBuilder = firstMust.nested();
+        assertThat(nestedQueryBuilder.scoreMode(), is(ChildScoreMode.Avg));
+        final Query innerQueryBuilder = nestedQueryBuilder.query();
+        assertThat(innerQueryBuilder.bool(), notNullValue());
+        final BoolQuery innerBoolQueryBuilder = innerQueryBuilder.bool();
 
         assertThat(innerBoolQueryBuilder.should(), hasSize(0));
         assertThat(innerBoolQueryBuilder.filter(), hasSize(0));
@@ -38,25 +37,25 @@ public abstract class AbstractQueryBuilderServiceTest {
         assertThat(innerBoolQueryBuilder.must(), hasSize(1));
     }
 
-    protected void checkExactMatchesNestedFilter(final QueryBuilder resultQueryBuilder,
+    protected void checkExactMatchesNestedFilter(final Query resultQuery,
                                                  final int mustSize, final int innerMust) {
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        final BoolQueryBuilder resultQueryBuilderAsBool = (BoolQueryBuilder) resultQueryBuilder;
+        final BoolQuery resultQueryBuilderAsBool = resultQuery.bool();
+        assertThat(resultQueryBuilderAsBool, notNullValue());
+
         assertThat(resultQueryBuilderAsBool.filter(), hasSize(0));
         assertThat(resultQueryBuilderAsBool.should(), hasSize(0));
         assertThat(resultQueryBuilderAsBool.mustNot(), hasSize(0));
-        final List<QueryBuilder> must = resultQueryBuilderAsBool.must();
+        final List<Query> must = resultQueryBuilderAsBool.must();
         assertThat(must, hasSize(mustSize));
 
         if (mustSize > 0) {
-            final QueryBuilder firstMust = resultQueryBuilderAsBool.must().get(0);
-            assertThat(firstMust, instanceOf(QueryBuilder.class));
-            final NestedQueryBuilder nestedQueryBuilder = (NestedQueryBuilder) firstMust;
-            assertThat(nestedQueryBuilder.getName(), is("nested"));
-            assertThat(nestedQueryBuilder.scoreMode(), is(Avg));
-            final QueryBuilder innerQueryBuilder = nestedQueryBuilder.query();
-            assertThat(innerQueryBuilder, instanceOf(BoolQueryBuilder.class));
-            final BoolQueryBuilder innerBoolQueryBuilder = (BoolQueryBuilder) innerQueryBuilder;
+            final Query firstMust = resultQueryBuilderAsBool.must().get(0);
+            assertThat(firstMust, notNullValue());
+            final NestedQuery nestedQueryBuilder = firstMust.nested();
+            assertThat(nestedQueryBuilder.scoreMode(), is(ChildScoreMode.Avg));
+            final Query innerQueryBuilder = nestedQueryBuilder.query();
+            assertThat(innerQueryBuilder.bool(), notNullValue());
+            final BoolQuery innerBoolQueryBuilder = innerQueryBuilder.bool();
 
             assertThat(innerBoolQueryBuilder.should(), hasSize(0));
             assertThat(innerBoolQueryBuilder.filter(), hasSize(0));

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/CpsCaseQueryBuilderServiceTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/service/CpsCaseQueryBuilderServiceTest.java
@@ -1,8 +1,8 @@
 package uk.gov.moj.cpp.unifiedsearch.query.builders.service;
 
 import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -24,6 +24,15 @@ import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchCo
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.PROSECUTOR;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.URN;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilder;
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.ElasticSearchQueryBuilderCache;
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.DateOfBirthSearchQueryBuilder;
@@ -45,15 +54,6 @@ import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps.Pa
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps.ProsecutorSearchQueryBuilder;
 import uk.gov.moj.cpp.unifiedsearch.query.builders.elasticsearch.builders.cps.UrnSearchQueryBuilder;
 import uk.gov.moj.cpp.unifiedsearch.query.common.domain.CpsQueryParameters;
-
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceTest {
@@ -104,7 +104,7 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
     private CourtHouseQueryBuilder courtHouseQueryBuilder;
 
     @Mock
-    private QueryBuilder queryBuilder;
+    private Query query;
 
     @Mock
     private ProsecutorSearchQueryBuilder prosecutorSearchQueryBuilder;
@@ -135,11 +135,12 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         final CpsQueryParameters queryParameters = new CpsQueryParameters.CpsQueryParametersBuilder()
                 .build();
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query resultQuery = resultQueryBuilder.build();
+        final BoolQuery boolQuery = resultQuery.bool();
 
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).must(), hasSize(0));
+        assertThat(boolQuery, notNullValue());
+        assertThat(boolQuery.must(), hasSize(0));
     }
 
     @Test
@@ -151,11 +152,12 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
                 .withProsecutor("  ")
                 .build();
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final BoolQuery boolQuery = resultQueryBuilder.build().bool();
 
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
+        assertThat(boolQuery, notNullValue());
 
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).must(), hasSize(0));
+        assertThat(boolQuery.must(), hasSize(0));
 
         verifyNoMoreInteractions(urnSearchQueryBuilder);
     }
@@ -171,12 +173,13 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(URN))
                 .thenReturn(urnSearchQueryBuilder);
         when(urnSearchQueryBuilder.getQueryBuilderBy(urn))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final BoolQuery boolQuery = resultQueryBuilder.build().bool();
 
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).filter(), hasSize(1));
+        assertThat(boolQuery, notNullValue());
+        assertThat(boolQuery.filter(), hasSize(1));
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(URN);
         verify(urnSearchQueryBuilder).getQueryBuilderBy(urn);
@@ -195,12 +198,13 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(CASE_STATUS))
                 .thenReturn(caseStatusQueryBuilder);
         when(caseStatusQueryBuilder.getQueryBuilderBy(caseStatus))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final BoolQuery boolQuery = resultQueryBuilder.build().bool();
 
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).filter(), hasSize(1));
+        assertThat(boolQuery, notNullValue());
+        assertThat(boolQuery.filter(), hasSize(1));
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(CASE_STATUS);
         verify(caseStatusQueryBuilder).getQueryBuilderBy(caseStatus);
@@ -219,12 +223,13 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(CASE_TYPE))
                 .thenReturn(caseTypeQueryBuilder);
         when(caseTypeQueryBuilder.getQueryBuilderBy(caseType))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final BoolQuery boolQuery = resultQueryBuilder.build().bool();
 
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).filter(), hasSize(1));
+        assertThat(boolQuery, notNullValue());
+        assertThat(boolQuery.filter(), hasSize(1));
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(CASE_TYPE);
         verify(caseTypeQueryBuilder).getQueryBuilderBy(caseType);
@@ -243,12 +248,13 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(CPS_UNIT))
                 .thenReturn(cpsUnitQueryBuilder);
         when(cpsUnitQueryBuilder.getQueryBuilderBy(cpsUnit))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final BoolQuery boolQuery = resultQueryBuilder.build().bool();
 
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).filter(), hasSize(1));
+        assertThat(boolQuery, notNullValue());
+        assertThat(boolQuery.filter(), hasSize(1));
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(CPS_UNIT);
         verify(cpsUnitQueryBuilder).getQueryBuilderBy(cpsUnit);
@@ -267,12 +273,13 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(CJS_AREA))
                 .thenReturn(cjsAreaQueryBuilder);
         when(cjsAreaQueryBuilder.getQueryBuilderBy(cjsArea))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final BoolQuery boolQuery = resultQueryBuilder.build().bool();
 
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).filter(), hasSize(1));
+        assertThat(boolQuery, notNullValue());
+        assertThat(boolQuery.filter(), hasSize(1));
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(CJS_AREA);
         verify(cjsAreaQueryBuilder).getQueryBuilderBy(cjsArea);
@@ -291,12 +298,12 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(OPERATION_NAME))
                 .thenReturn(operationNameQueryBuilder);
         when(operationNameQueryBuilder.getQueryBuilderBy(operationName))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
-
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).filter(), hasSize(1));
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final BoolQuery boolQuery = resultQueryBuilder.build().bool();
+        assertThat(boolQuery, notNullValue());
+        assertThat(boolQuery.filter(), hasSize(1));
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(OPERATION_NAME);
         verify(operationNameQueryBuilder).getQueryBuilderBy(operationName);
@@ -315,12 +322,12 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(PARALEGAL_OFFICER))
                 .thenReturn(paralegalOfficerQueryBuilder);
         when(paralegalOfficerQueryBuilder.getQueryBuilderBy(paralegalOfficer))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
-
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).filter(), hasSize(1));
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query resultQuery = resultQueryBuilder.build();
+        assertThat(resultQuery.bool(), notNullValue());
+        assertThat(resultQuery.bool().filter(), hasSize(1));
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(PARALEGAL_OFFICER);
         verify(paralegalOfficerQueryBuilder).getQueryBuilderBy(paralegalOfficer);
@@ -339,12 +346,13 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(CROWN_ADVOCATE))
                 .thenReturn(crownAdvocateQueryBuilder);
         when(crownAdvocateQueryBuilder.getQueryBuilderBy(crownAdvocate))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
-
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).filter(), hasSize(1));
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query resultQuery = resultQueryBuilder.build();
+        final BoolQuery boolQuery = resultQuery.bool();
+        assertThat(boolQuery, notNullValue());
+        assertThat(boolQuery.filter(), hasSize(1));
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(CROWN_ADVOCATE);
         verify(crownAdvocateQueryBuilder).getQueryBuilderBy(crownAdvocate);
@@ -362,12 +370,14 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(PROSECUTOR))
                 .thenReturn(prosecutorSearchQueryBuilder);
         when(prosecutorSearchQueryBuilder.getQueryBuilderBy(prosecutingAuthority))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query resultQuery = resultQueryBuilder.build();
+        final BoolQuery boolQuery = resultQuery.bool();
 
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).filter(), hasSize(1));
+        assertThat(boolQuery, notNullValue());
+        assertThat(boolQuery.filter(), hasSize(1));
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(PROSECUTOR);
         verify(prosecutorSearchQueryBuilder).getQueryBuilderBy(prosecutingAuthority);
@@ -387,11 +397,12 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(HEARING_DATE_TIME))
                 .thenReturn(hearingDateTimeQueryBuilder);
         when(hearingDateTimeQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
 
-        checkNestedFilter(resultQueryBuilder);
+        final Query resultQuery = resultQueryBuilder.build();
+        checkNestedFilter(resultQuery);
 
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(HEARING_DATE_TIME);
@@ -414,11 +425,12 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
                 .thenReturn(hearingDateTimeQueryBuilder);
 
         when(hearingDateTimeQueryBuilder.getQueryBuilderBy(hearingDateFrom, hearingDateTo))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
 
-        checkNestedFilter(resultQueryBuilder);
+        final Query resultQuery = resultQueryBuilder.build();
+        checkNestedFilter(resultQuery);
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(HEARING_DATE_TIME);
         verify(hearingDateTimeQueryBuilder).getQueryBuilderBy(hearingDateFrom, hearingDateTo);
@@ -433,9 +445,10 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
                 .withPartyTypes(partyTypes)
                 .build();
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
 
-        checkExactMatchesNestedFilter(resultQueryBuilder, 0, 0);
+        final Query resultQuery = resultQueryBuilder.build();
+        checkExactMatchesNestedFilter(resultQuery, 0, 0);
 
         verifyNoMoreInteractions(partyTypeQueryBuilder);
     }
@@ -450,11 +463,12 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
 
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(DATE_OF_BIRTH))
                 .thenReturn(elasticSearchQueryBuilder);
-        when(elasticSearchQueryBuilder.getQueryBuilderBy(dateOfBirth)).thenReturn(queryBuilder);
+        when(elasticSearchQueryBuilder.getQueryBuilderBy(dateOfBirth)).thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
 
-        checkNestedFilter(resultQueryBuilder);
+        final Query resultQuery = resultQueryBuilder.build();
+        checkNestedFilter(resultQuery);
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(DATE_OF_BIRTH);
         verify(elasticSearchQueryBuilder).getQueryBuilderBy(dateOfBirth);
@@ -471,11 +485,12 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
 
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(COURT_HOUSE))
                 .thenReturn(courtHouseQueryBuilder);
-        when(courtHouseQueryBuilder.getQueryBuilderBy(courtHouse)).thenReturn(queryBuilder);
+        when(courtHouseQueryBuilder.getQueryBuilderBy(courtHouse)).thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
 
-        checkNestedFilter(resultQueryBuilder);
+        final Query resultQuery = resultQueryBuilder.build();
+        checkNestedFilter(resultQuery);
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(COURT_HOUSE);
         verify(courtHouseQueryBuilder).getQueryBuilderBy(courtHouse);
@@ -492,11 +507,12 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
 
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(JURISDICTION))
                 .thenReturn(jurisdictionQueryBuilder);
-        when(jurisdictionQueryBuilder.getQueryBuilderBy(jurisdiction)).thenReturn(queryBuilder);
+        when(jurisdictionQueryBuilder.getQueryBuilderBy(jurisdiction)).thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
 
-        checkNestedFilter(resultQueryBuilder);
+        final Query resultQuery = resultQueryBuilder.build();
+        checkNestedFilter(resultQuery);
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(JURISDICTION);
         verify(jurisdictionQueryBuilder).getQueryBuilderBy(jurisdiction);
@@ -513,11 +529,12 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
 
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(COURT_ROOM))
                 .thenReturn(courtRoomQueryBuilder);
-        when(courtRoomQueryBuilder.getQueryBuilderBy(courtRoom)).thenReturn(queryBuilder);
+        when(courtRoomQueryBuilder.getQueryBuilderBy(courtRoom)).thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
 
-        checkNestedFilter(resultQueryBuilder);
+        final Query resultQuery = resultQueryBuilder.build();
+        checkNestedFilter(resultQuery);
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(COURT_ROOM);
         verify(courtRoomQueryBuilder).getQueryBuilderBy(courtRoom);
@@ -536,12 +553,14 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(CPS_AREA))
                 .thenReturn(cpsAreaQueryBuilder);
         when(cpsAreaQueryBuilder.getQueryBuilderBy(cpsArea))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query resultQuery = resultQueryBuilder.build();
+        final BoolQuery boolQuery = resultQuery.bool();
 
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).filter(), hasSize(1));
+        assertThat(boolQuery, notNullValue());
+        assertThat(boolQuery.filter(), hasSize(1));
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(CPS_AREA);
         verify(cpsAreaQueryBuilder).getQueryBuilderBy(cpsArea);
@@ -560,12 +579,14 @@ public class CpsCaseQueryBuilderServiceTest extends AbstractQueryBuilderServiceT
         when(elasticSearchQueryBuilderCache.getQueryBuilderFromCacheBy(LINKED_CASE_ID))
                 .thenReturn(excludeAutomaticallyLinkedCasesQueryBuilder);
         when(excludeAutomaticallyLinkedCasesQueryBuilder.getQueryBuilderBy(excludeCaseId))
-                .thenReturn(queryBuilder);
+                .thenReturn(query);
 
-        final QueryBuilder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query.Builder resultQueryBuilder = cpsCaseQueryBuilderService.builder(queryParameters);
+        final Query resultQuery = resultQueryBuilder.build();
+        final BoolQuery boolQuery = resultQuery.bool();
 
-        assertThat(resultQueryBuilder, instanceOf(BoolQueryBuilder.class));
-        assertThat(((BoolQueryBuilder) resultQueryBuilder).filter(), hasSize(1));
+        assertThat(boolQuery, notNullValue());
+        assertThat(boolQuery.filter(), hasSize(1));
 
         verify(elasticSearchQueryBuilderCache).getQueryBuilderFromCacheBy(LINKED_CASE_ID);
         verify(excludeAutomaticallyLinkedCasesQueryBuilder).getQueryBuilderBy(excludeCaseId);

--- a/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/utils/EnumValidatorTest.java
+++ b/unifiedsearchquery-builders/src/test/java/uk/gov/moj/cpp/unifiedsearch/query/builders/utils/EnumValidatorTest.java
@@ -3,7 +3,7 @@ package uk.gov.moj.cpp.unifiedsearch.query.builders.utils;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.elasticsearch.search.sort.SortOrder;
+import co.elastic.clients.elasticsearch._types.SortOrder;
 import org.junit.jupiter.api.Test;
 
 public class EnumValidatorTest {

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-SNAPSHOT</version>
+        <version>17.103.1-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-DD-41592-SNAPSHOT</version>
+        <version>17.103.2-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -15,8 +15,8 @@
             <artifactId>unifiedsearch-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
+            <groupId>co.elastic.clients</groupId>
+            <artifactId>elasticsearch-java</artifactId>
         </dependency>
 
         <dependency>

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.2-DD-41592-SNAPSHOT</version>
+        <version>17.103.3-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.5-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.3-DD-41592-SNAPSHOT</version>
+        <version>17.103.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.5-DD-41592-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/constant/CpsCaseSearchConstants.java
+++ b/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/constant/CpsCaseSearchConstants.java
@@ -1,9 +1,8 @@
 package uk.gov.moj.cpp.unifiedsearch.query.common.constant;
 
 
-import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
-
-import org.elasticsearch.index.query.RangeQueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.json.JsonData;
 
 public class CpsCaseSearchConstants {
 
@@ -78,7 +77,13 @@ public class CpsCaseSearchConstants {
     public static final String OFFENCE_DESCRIPTION_SORT_BY = "offenceDescription";
     public static final String DEFENDANT_LASTNAME_SORT_BY = "defendantLastName";
     public static final String PARTY_LASTNAME_OR_ORGANISATIONNAME_SORT_BY = "partyLastOrOrganisationName";
-    public static final RangeQueryBuilder HEARING_DATE_NESTED_FILTER = rangeQuery(HEARING_DATE_TIME_PATH).gte("now");
+    public static final Query HEARING_DATE_NESTED_FILTER =
+            Query.of(q -> q.range(r -> r
+                    .untyped(u -> u
+                            .field(HEARING_DATE_TIME_PATH)
+                            .gte(JsonData.of("now"))
+                    )
+            ));
 
     private CpsCaseSearchConstants() {
     }

--- a/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/constant/CpsCaseSortBy.java
+++ b/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/constant/CpsCaseSortBy.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.elasticsearch.index.query.QueryBuilder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 public enum CpsCaseSortBy {
 
@@ -34,7 +34,7 @@ public enum CpsCaseSortBy {
     private String fieldName;
 
     //Apply this filter before sorting
-    private final Optional<QueryBuilder> nestedFilter;
+    private final Optional<Query> nestedFilter;
     //How many children matching the above filter to consider for sorting
     private final Optional<Integer> nestedMaxChildren;
 
@@ -49,7 +49,7 @@ public enum CpsCaseSortBy {
         );
     }
 
-    CpsCaseSortBy(final String keyName, final String fieldName, final Optional<String> nestedPath, final Optional<QueryBuilder> nestedFilter, final Optional<Integer> nestedMaxChildren) {
+    CpsCaseSortBy(final String keyName, final String fieldName, final Optional<String> nestedPath, final Optional<Query> nestedFilter, final Optional<Integer> nestedMaxChildren) {
         this.keyName = keyName;
         this.fieldName = fieldName;
         this.nestedPath = nestedPath;
@@ -73,7 +73,7 @@ public enum CpsCaseSortBy {
         return lookUp.putIfAbsent(keyName, URN);
     }
 
-    public Optional<QueryBuilder> getNestedFilter() {
+    public Optional<Query> getNestedFilter() {
         return nestedFilter;
     }
 

--- a/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/constant/CpsCaseSortBy.java
+++ b/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/constant/CpsCaseSortBy.java
@@ -70,7 +70,7 @@ public enum CpsCaseSortBy {
     }
 
     public static CpsCaseSortBy findByKeyNameOrDefault(final String keyName) {
-        return lookUp.putIfAbsent(keyName, URN);
+        return lookUp.computeIfAbsent(keyName, key -> URN);
     }
 
     public Optional<Query> getNestedFilter() {

--- a/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/constant/SortOrder.java
+++ b/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/constant/SortOrder.java
@@ -1,5 +1,6 @@
 package uk.gov.moj.cpp.unifiedsearch.query.common.constant;
 
+@SuppressWarnings("java:S115")
 public enum SortOrder {
     ASC("Asc"),
     DESC("Desc"),

--- a/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/constant/SortOrder.java
+++ b/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/constant/SortOrder.java
@@ -1,0 +1,17 @@
+package uk.gov.moj.cpp.unifiedsearch.query.common.constant;
+
+public enum SortOrder {
+    ASC("Asc"),
+    DESC("Desc"),
+    Asc("Asc"),
+    Desc("Desc"),
+    asc("Asc"),
+    desc("Desc");
+
+    private String order;
+
+    private SortOrder(final String order){ this.order = order;}
+
+    public String getOrder(){ return this.order;}
+
+}

--- a/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/domain/CpsQueryParameters.java
+++ b/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/domain/CpsQueryParameters.java
@@ -1,7 +1,7 @@
 package uk.gov.moj.cpp.unifiedsearch.query.common.domain;
 
 
-import org.elasticsearch.search.sort.SortOrder;
+import uk.gov.moj.cpp.unifiedsearch.query.common.constant.SortOrder;
 
 public class CpsQueryParameters {
 

--- a/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/domain/CpsQueryParameters.java
+++ b/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/domain/CpsQueryParameters.java
@@ -5,7 +5,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.common.constant.SortOrder;
 
 public class CpsQueryParameters {
 
-    private int pageSize = 10;
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private int pageSize = DEFAULT_PAGE_SIZE;
     private int startFrom;
     private String urn;
     private String firstName;
@@ -100,7 +101,10 @@ public class CpsQueryParameters {
     }
 
     public int getPageSize() {
-        return pageSize;
+        // The framework materialises an absent pageSize query param as 0; treat 0 as
+        // "use the default page size". Negative values stay invalid and are rejected by
+        // QueryApiPreConditions.
+        return pageSize == 0 ? DEFAULT_PAGE_SIZE : pageSize;
     }
 
     public int getStartFrom() {

--- a/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/domain/QueryParameters.java
+++ b/unifiedsearchquery-domain-common/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/common/domain/QueryParameters.java
@@ -3,7 +3,8 @@ package uk.gov.moj.cpp.unifiedsearch.query.common.domain;
 
 public class QueryParameters {
 
-    private int pageSize = 10;
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private int pageSize = DEFAULT_PAGE_SIZE;
 
     private int startFrom;
 
@@ -134,7 +135,10 @@ public class QueryParameters {
     }
 
     public int getPageSize() {
-        return pageSize;
+        // The framework materialises an absent pageSize query param as 0; treat 0 as
+        // "use the default page size". Negative values stay invalid and are rejected by
+        // QueryApiPreConditions.
+        return pageSize == 0 ? DEFAULT_PAGE_SIZE : pageSize;
     }
 
     public int getStartFrom() {

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-SNAPSHOT</version>
+        <version>17.103.1-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-DD-41592-SNAPSHOT</version>
+        <version>17.103.2-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.2-DD-41592-SNAPSHOT</version>
+        <version>17.103.3-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.5-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.3-DD-41592-SNAPSHOT</version>
+        <version>17.103.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.5-DD-41592-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -11,8 +11,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/unifiedsearchquery-healthchecks/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/healthchecks/UnifiedSearchQueryIgnoredHealthcheckNamesProvider.java
+++ b/unifiedsearchquery-healthchecks/src/main/java/uk/gov/moj/cpp/unifiedsearch/query/healthchecks/UnifiedSearchQueryIgnoredHealthcheckNamesProvider.java
@@ -6,7 +6,7 @@ import uk.gov.justice.services.healthcheck.api.DefaultIgnoredHealthcheckNamesPro
 
 import java.util.List;
 
-import javax.enterprise.inject.Specializes;
+import jakarta.enterprise.inject.Specializes;
 
 @Specializes
 public class UnifiedSearchQueryIgnoredHealthcheckNamesProvider extends DefaultIgnoredHealthcheckNamesProvider {

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-SNAPSHOT</version>
+        <version>17.103.1-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-DD-41592-SNAPSHOT</version>
+        <version>17.103.2-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.2-DD-41592-SNAPSHOT</version>
+        <version>17.103.3-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.5-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.3-DD-41592-SNAPSHOT</version>
+        <version>17.103.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.5-DD-41592-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/cps/PageSizeAndStartFromQueryIT.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/cps/PageSizeAndStartFromQueryIT.java
@@ -86,10 +86,12 @@ public class PageSizeAndStartFromQueryIT {
     }
 
     @Test
-    public void shouldReturnNothingWhenPageSizeIs0() throws IOException {
+    public void shouldUseDefaultPageSizeWhenPageSizeIs0() throws IOException {
+        // pageSize=0 (like an absent pageSize) means "use the default page size (10)",
+        // so all 6 matching cases are returned rather than none.
         final List<Case> caseListResults = searchByPageSizeAndStartFrom(0, 0);
 
-        assertThat(caseListResults, hasSize(0));
+        assertThat(caseListResults, hasSize(6));
     }
 
 

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/cps/SortByHearingDateQueryIT.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/cps/SortByHearingDateQueryIT.java
@@ -1,7 +1,5 @@
 package uk.gov.moj.unifiedsearch.query.it.cps;
 
-import static org.elasticsearch.search.sort.SortOrder.ASC;
-import static org.elasticsearch.search.sort.SortOrder.DESC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.CPS_CASE_INDEX_NAME;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.HEARING_DATE_SORT_BY;
@@ -40,7 +38,7 @@ public class SortByHearingDateQueryIT {
     public void shouldReturnCasesOrderedByHearingDateTimeDesc() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, HEARING_DATE_SORT_BY);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -53,7 +51,7 @@ public class SortByHearingDateQueryIT {
     public void shouldReturnCasesOrderedByHearingDateTimeAsc() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, HEARING_DATE_SORT_BY);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/cps/SortByQueryIT.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/cps/SortByQueryIT.java
@@ -3,8 +3,6 @@ package uk.gov.moj.unifiedsearch.query.it.cps;
 import static java.util.Comparator.reverseOrder;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
-import static org.elasticsearch.search.sort.SortOrder.ASC;
-import static org.elasticsearch.search.sort.SortOrder.DESC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static uk.gov.moj.cpp.unifiedsearch.query.common.constant.CpsCaseSearchConstants.CASE_STATUS_SORT_BY;
@@ -80,7 +78,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByDateOfBirth() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, DATE_OF_BIRTH);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -99,7 +97,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByDateOfBirth() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, DATE_OF_BIRTH);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -118,7 +116,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByHearingDateTime() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, HEARING_DATE_SORT_BY);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -134,7 +132,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByHearingDateTime() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, HEARING_DATE_SORT_BY);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -150,7 +148,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByHearingType() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, HEARING_TYPE);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -166,7 +164,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByHearingType() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, HEARING_TYPE);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -182,7 +180,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByCourtRoom() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, COURT_ROOM);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -198,7 +196,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByCourtRoom() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, COURT_ROOM);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -214,7 +212,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByCourtHouse() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, COURT_HOUSE);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -230,7 +228,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByCourtHouse() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, COURT_HOUSE);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
         final List<Hearing> hearings = flatMapHearingsFromCases(caseSearchResponse);
@@ -245,7 +243,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByProsecutor() throws Exception {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, PROSECUTOR);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -261,7 +259,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByProsecutor() throws Exception {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, PROSECUTOR);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -277,7 +275,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByParalegalOfficer() throws Exception {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, PARALEGAL_OFFICER);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -293,7 +291,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByParalegalOfficer() throws Exception {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, PARALEGAL_OFFICER);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -309,7 +307,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByCrownAdvocate() throws Exception {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, CROWN_ADVOCATE);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -325,7 +323,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByCrownAdvocate() throws Exception {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, CROWN_ADVOCATE);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -341,7 +339,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByUrn() throws Exception {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, URN);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -357,7 +355,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByUrn() throws Exception {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, URN);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -373,7 +371,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByCaseStatus() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, CASE_STATUS_SORT_BY);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -389,7 +387,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByCaseStatus() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, CASE_STATUS_SORT_BY);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -406,7 +404,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByPartyLastNameOrOrganisationName() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, PARTY_LASTNAME_OR_ORGANISATIONNAME_SORT_BY);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -433,7 +431,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByPartyLastNameOrOrganisationName() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, PARTY_LASTNAME_OR_ORGANISATIONNAME_SORT_BY);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -460,7 +458,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByDefendantLastName() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, DEFENDANT_LASTNAME_SORT_BY);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -479,7 +477,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByDefendantLastName() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, DEFENDANT_LASTNAME_SORT_BY);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -498,7 +496,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedAscendingByOffenceDescription() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, OFFENCE_DESCRIPTION_SORT_BY);
-        parameters.putIfAbsent(ORDER, ASC.toString());
+        parameters.putIfAbsent(ORDER, "ASC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 
@@ -516,7 +514,7 @@ public class SortByQueryIT {
     public void shouldReturnCasesAsSortedDescendingByOffenceDescription() throws IOException {
         final Map<String, String> parameters = new HashMap();
         parameters.putIfAbsent(ORDER_BY, OFFENCE_DESCRIPTION_SORT_BY);
-        parameters.putIfAbsent(ORDER, DESC.toString());
+        parameters.putIfAbsent(ORDER, "DESC");
 
         final CaseSearchResponse caseSearchResponse = searchApiClient.searchCases(parameters);
 

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/ingestors/HearingDateSearchDataIngester.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/ingestors/HearingDateSearchDataIngester.java
@@ -6,8 +6,11 @@ import static java.util.stream.Collectors.toList;
 import static uk.gov.moj.cpp.unifiedsearch.test.util.ingest.mothers.CaseDocumentMother.defaultCasesAsBuilderList;
 import static uk.gov.moj.cpp.unifiedsearch.test.util.ingest.mothers.HearingDayDocumentMother.hearingDays;
 import static uk.gov.moj.cpp.unifiedsearch.test.util.ingest.mothers.HearingDocumentMother.defaultHearingAsBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.test.util.ingest.mothers.OffenceDocumentMother.defaultOffenceDocument;
 import static uk.gov.moj.cpp.unifiedsearch.test.util.ingest.mothers.PartyDocumentMother.defaultPartyAsBuilder;
+import static uk.gov.moj.cpp.unifiedsearch.test.util.ingest.mothers.RepresentationOrderDocumentMother.defaultRepresentationOrder;
 
+import uk.gov.moj.cpp.unifiedsearch.test.util.constant.PartyType;
 import uk.gov.moj.cpp.unifiedsearch.test.util.ingest.ElasticSearchIndexIngestorUtil;
 import uk.gov.moj.cpp.unifiedsearch.test.util.ingest.document.CaseDocument;
 import uk.gov.moj.cpp.unifiedsearch.test.util.ingest.document.HearingDocument;
@@ -51,14 +54,14 @@ public class HearingDateSearchDataIngester {
         caseBuilderList.get(0).withParties(asList(
                 createParty(PARTY_POSTCODE_CR0_2AB, "", "", "", "last1"),
                 createParty("RH16 2BW", "", "", "", "last2"),
-                createParty("SL12 3AZ", "MOJ", "Joe", "Sam", "Doe")));
+                createDefendantParty("SL12 3AZ", "MOJ", "Joe", "Sam", "Doe")));
         caseBuilderList.get(1).withHearings(singletonList(hearingDocumentBuilder2));
         caseBuilderList.get(2).withHearings(singletonList(hearingDocumentBuilder5));
         caseBuilderList.get(3).withHearings(asList(hearingDocumentBuilder3, hearingDocumentBuilder1));
         caseBuilderList.get(3).withParties(asList(
                 createParty(PARTY_POSTCODE_CR0_2AB,"", "", "", "last3"),
                 createParty("RH16 2BW","org1", "", "", ""),
-                createParty("SL12 3AZ", "MOJ", "Joe", "Sam", "Doe")));
+                createDefendantParty("SL12 3AZ", "MOJ", "Joe", "Sam", "Doe")));
 
         caseBuilderList.get(4).withHearings(asList(hearingDocumentBuilder5, hearingDocumentBuilder2));
 
@@ -80,6 +83,22 @@ public class HearingDateSearchDataIngester {
                 .withMiddleName(middleName)
                 .withLastName(lastName);
         return partyBuilder;
+    }
+
+    /**
+     * A searchable defendant party. {@code defaultPartyAsBuilder()} randomly makes a party a DEFENDANT (with
+     * offences) or an APPLICANT (no offences); the LAA "defendantName" search requires the matched party to have
+     * offences ({@code parties.offences} EXISTS), so a randomly-APPLICANT "Joe" party matched only intermittently —
+     * that was the flake. Pin the searched party to a complete DEFENDANT (type + offences + ASN + representation
+     * order) so it is deterministically matched, and so the probation-details assertions have the offences they read.
+     */
+    private static PartyDocument.Builder createDefendantParty(final String postcode, final String orgName, final String firstName, final String middleName, final String lastName) {
+        return createParty(postcode, orgName, firstName, middleName, lastName)
+                .withPartyType(PartyType.DEFENDANT.name())
+                .withArrestSummonsNumber("ASN 1234")
+                .withOffences(asList(defaultOffenceDocument()))
+                .withProceedingsConcluded(false)
+                .withRepresentationOrder(defaultRepresentationOrder());
     }
 
     public CaseDocument getIndexDocumentAt(int index) {

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/ingestors/NameQueryDataIngester.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/ingestors/NameQueryDataIngester.java
@@ -1,6 +1,7 @@
 package uk.gov.moj.unifiedsearch.query.it.ingestors;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.moj.cpp.unifiedsearch.test.util.ingest.mothers.CaseDocumentMother.defaultCasesAsBuilderList;
@@ -29,20 +30,26 @@ public class NameQueryDataIngester {
 
         final List<CaseDocument.Builder> caseBuilderList = defaultCasesAsBuilderList(10);
 
-        final PartyDocument.Builder markSpencerBuilder = defaultPartyAsBuilder().withFirstName("Mark").withLastName("Spencer").withMiddleName(null).withOrganisationName(null);
-        final PartyDocument.Builder spencerMarkBuilder = defaultPartyAsBuilder().withFirstName("Spencer").withMiddleName(null).withOrganisationName(null).withLastName("Mark");
+        // NOTE: withAliases(emptyList()) is essential. defaultPartyAsBuilder() attaches 0-2 RANDOM aliases
+        // whose last name is drawn from a pool that includes "Spencer" (RandomNames.LAST_NAMES), and this
+        // search matches parties.aliases.lastName (see LastOrOrganisationNameLeafQueryBuilder). A random
+        // "Spencer" alias intermittently added one extra hit ("spencer" -> 10 vs the expected 9), a genuine
+        // flake. Pinning aliases to empty makes the match set deterministic (the org-name builders below
+        // never flaked precisely because they use a bare Builder with no aliases).
+        final PartyDocument.Builder markSpencerBuilder = defaultPartyAsBuilder().withFirstName("Mark").withLastName("Spencer").withMiddleName(null).withOrganisationName(null).withAliases(emptyList());
+        final PartyDocument.Builder spencerMarkBuilder = defaultPartyAsBuilder().withFirstName("Spencer").withMiddleName(null).withOrganisationName(null).withLastName("Mark").withAliases(emptyList());
 
-        final PartyDocument.Builder marksSpencersBuilder = defaultPartyAsBuilder().withFirstName("Marks").withMiddleName(null).withOrganisationName(null).withLastName("Spencers");
-        final PartyDocument.Builder spencersMarksBuilder = defaultPartyAsBuilder().withFirstName("Spencers").withLastName("Marks").withMiddleName(null).withOrganisationName(null);
+        final PartyDocument.Builder marksSpencersBuilder = defaultPartyAsBuilder().withFirstName("Marks").withMiddleName(null).withOrganisationName(null).withLastName("Spencers").withAliases(emptyList());
+        final PartyDocument.Builder spencersMarksBuilder = defaultPartyAsBuilder().withFirstName("Spencers").withLastName("Marks").withMiddleName(null).withOrganisationName(null).withAliases(emptyList());
 
-        final PartyDocument.Builder markSpencersBuilder = defaultPartyAsBuilder().withFirstName("Mark").withLastName("Spencers").withMiddleName(null).withOrganisationName(null);
-        final PartyDocument.Builder spencersMarkBuilder = defaultPartyAsBuilder().withFirstName("Spencers").withMiddleName(null).withOrganisationName(null).withLastName("Mark");
+        final PartyDocument.Builder markSpencersBuilder = defaultPartyAsBuilder().withFirstName("Mark").withLastName("Spencers").withMiddleName(null).withOrganisationName(null).withAliases(emptyList());
+        final PartyDocument.Builder spencersMarkBuilder = defaultPartyAsBuilder().withFirstName("Spencers").withMiddleName(null).withOrganisationName(null).withLastName("Mark").withAliases(emptyList());
 
-        final PartyDocument.Builder marksSpencerBuilder = defaultPartyAsBuilder().withFirstName("Marks").withLastName("Spencer").withMiddleName(null).withOrganisationName(null);
-        final PartyDocument.Builder spencerMarksBuilder = defaultPartyAsBuilder().withFirstName("Spencer").withMiddleName(null).withOrganisationName(null).withLastName("Marks");
+        final PartyDocument.Builder marksSpencerBuilder = defaultPartyAsBuilder().withFirstName("Marks").withLastName("Spencer").withMiddleName(null).withOrganisationName(null).withAliases(emptyList());
+        final PartyDocument.Builder spencerMarksBuilder = defaultPartyAsBuilder().withFirstName("Spencer").withMiddleName(null).withOrganisationName(null).withLastName("Marks").withAliases(emptyList());
 
-        final PartyDocument.Builder markAndSpencerBuilder = defaultPartyAsBuilder().withFirstName("x").withLastName("Mark And Spencer").withMiddleName(null).withOrganisationName(null);
-        final PartyDocument.Builder marksAndSpencersBuilder = defaultPartyAsBuilder().withFirstName("x").withLastName("Marks And Spencers").withMiddleName(null).withOrganisationName(null);
+        final PartyDocument.Builder markAndSpencerBuilder = defaultPartyAsBuilder().withFirstName("x").withLastName("Mark And Spencer").withMiddleName(null).withOrganisationName(null).withAliases(emptyList());
+        final PartyDocument.Builder marksAndSpencersBuilder = defaultPartyAsBuilder().withFirstName("x").withLastName("Marks And Spencers").withMiddleName(null).withOrganisationName(null).withAliases(emptyList());
 
 
         // Note the party names are added here in the order of expected relevance/order from the query:

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/CpsSearchApiClient.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/CpsSearchApiClient.java
@@ -5,7 +5,7 @@ import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.jboss.resteasy.util.HttpResponseCodes.SC_OK;
+import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.justice.services.test.utils.common.host.TestHostProvider.getHost;
 
 import uk.gov.justice.services.common.http.HeaderConstants;
@@ -14,8 +14,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.common.domain.response.cps.CaseSearchR
 import java.io.IOException;
 import java.util.Map;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/LaaSearchApiClient.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/LaaSearchApiClient.java
@@ -5,7 +5,7 @@ import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.jboss.resteasy.util.HttpResponseCodes.SC_OK;
+import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.justice.services.test.utils.common.host.TestHostProvider.getHost;
 
 import uk.gov.justice.services.common.http.HeaderConstants;
@@ -14,8 +14,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.common.domain.response.laa.CaseSearchR
 import java.io.IOException;
 import java.util.Map;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/ProbationDefendantDetailsSearchApiClient.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/ProbationDefendantDetailsSearchApiClient.java
@@ -5,7 +5,7 @@ import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.jboss.resteasy.util.HttpResponseCodes.SC_OK;
+import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.justice.services.test.utils.common.host.TestHostProvider.getHost;
 
 import uk.gov.justice.services.common.http.HeaderConstants;
@@ -14,8 +14,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.common.domain.response.probation.Proba
 import java.io.IOException;
 import java.util.Map;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/SearchApiClient.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/SearchApiClient.java
@@ -5,7 +5,7 @@ import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.jboss.resteasy.util.HttpResponseCodes.SC_OK;
+import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.justice.services.test.utils.common.host.TestHostProvider.getHost;
 
 import uk.gov.justice.services.common.http.HeaderConstants;
@@ -14,8 +14,8 @@ import uk.gov.moj.cpp.unifiedsearch.query.common.domain.response.CaseSearchRespo
 import java.io.IOException;
 import java.util.Map;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/StubUtils.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/StubUtils.java
@@ -24,7 +24,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 

--- a/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/WiremockTestHelper.java
+++ b/unifiedsearchquery-integration-test/src/test/java/uk/gov/moj/unifiedsearch/query/it/util/WiremockTestHelper.java
@@ -6,7 +6,7 @@ import static uk.gov.justice.services.test.utils.core.matchers.ResponseStatusMat
 
 import uk.gov.justice.services.test.utils.core.http.RequestParams;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public class WiremockTestHelper {
     private static final String HOST = System.getProperty("INTEGRATION_HOST_KEY", "localhost");

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-SNAPSHOT</version>
+        <version>17.103.1-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.1-DD-41592-SNAPSHOT</version>
+        <version>17.103.2-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.2-DD-41592-SNAPSHOT</version>
+        <version>17.103.3-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.5-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.3-DD-41592-SNAPSHOT</version>
+        <version>17.103.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.103.4-DD-41592-SNAPSHOT</version>
+        <version>17.104.4-DD-41592-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>17.104.5-DD-41592-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Java 25 / WildFly 40 / Elasticsearch 9.3.3 upgrade of unifiedsearch-query

Upgrades unifiedsearch-query to the released **25.104.x** chain (Java 25 / WildFly 40 / Jakarta EE 11) and to **Elasticsearch 9.3.3**. Base is `team/25.104.x` (cut from `main`), so the diff includes both the ES-9 context work and the Java-25 layer. Tracking: **PEG-3408**, mirroring the Java-17 **DD-41592** ES-9 upgrade. Details: [ES 9.3.3 Upgrade — Java 25 Confluence page](https://tools.hmcts.net/confluence/spaces/PETTA/pages/1990251336).

The 25.104.x framework/platform chain has released; this PR consumes the released milestones — in particular **`service-parent-pom:25.104.0-M9`**, which brings the Elasticsearch **9.3.3** client (`co.elastic.clients:elasticsearch-java`) via `cpp-platform-libraries` **M10** / `cpp-platform-maven-common-bom` **M4**, plus jackson `2.21.5` (CVE-2026-54515).

### Changes
- Parent → `service-parent-pom:25.104.0-M9` (released); `javax`→`jakarta`; `jakarta.xml.bind-api` override on the RAML client-generator plugins; `azure-pipelines.yaml` on the **wildfly40 / JDK 25** track.
- **Elasticsearch 9.3.3:** `elasticsearch.embedded.version` → `9.3.3`; the query client uses the ES-9 `co.elastic.clients` migration in `cpp-platform-libraries M10`. (9.2.2→9.3.3 needed no source changes — API-compatible.) `httpcore5` pinned `5.3.6` in the platform BOM.
- Context fixes surfaced by real ES-9 ITs: `CpsCaseSortBy` NPE (`computeIfAbsent`), `pageSize=0` → default page (see the ⚠️ note in `CLAUDE.md` re: API Tests), and a flaky `LastOrOrganisationNameLeafQueryIT` (random party alias) hardened.

### Validation
Full-stack integration tests against a **live Elasticsearch 9.3.3** container + WildFly 40 on JDK 25: **332 / 0 / 0** (3 skipped), plus unit + embedded-Elasticsearch tests green.