### PR TITLE
Bump milestone version to 25.104.1-M2-SNAPSHOT (re-trigger release + docker image)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ buildContexts.sh
 
 lightning-jenkins.properties
 **/.DS_Store
+
+# Maven Shade plugin generated artifact
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
     <artifactId>unifiedsearchquery-parent</artifactId>
-    <version>25.104.1-M1-SNAPSHOT</version>
+    <version>25.104.1-M2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Unifiedsearch Query Context - Parent Module</name>

--- a/unifiedsearchquery-api/pom.xml
+++ b/unifiedsearchquery-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>25.104.1-M1-SNAPSHOT</version>
+        <version>25.104.1-M2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-builders/pom.xml
+++ b/unifiedsearchquery-builders/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>25.104.1-M1-SNAPSHOT</version>
+        <version>25.104.1-M2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-domain-common/pom.xml
+++ b/unifiedsearchquery-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>25.104.1-M1-SNAPSHOT</version>
+        <version>25.104.1-M2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-healthchecks/pom.xml
+++ b/unifiedsearchquery-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>25.104.1-M1-SNAPSHOT</version>
+        <version>25.104.1-M2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-integration-test/pom.xml
+++ b/unifiedsearchquery-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>25.104.1-M1-SNAPSHOT</version>
+        <version>25.104.1-M2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/unifiedsearchquery-service/pom.xml
+++ b/unifiedsearchquery-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>unifiedsearchquery-parent</artifactId>
         <groupId>uk.gov.moj.cpp.unifiedsearch.query</groupId>
-        <version>25.104.1-M1-SNAPSHOT</version>
+        <version>25.104.1-M2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Bumps the project milestone version one step (`-M1` → `-M2`) across all modules to produce a real diff. The ADO release pipeline gates the artifact rebuild + ACR docker-image build on `shouldRebuildArtifacts`, which an empty commit does not set. This milestone bump forces it. Full build green with `-U` (no enforcer skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)